### PR TITLE
boto3 secrets manager methods to optional dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,30 @@
-.PHONY: init install update update-deps clean-pyc
+.PHONY: init dev-install update clean-pyc clean-tests run-tests
 
 init:
 	pip install --upgrade pip setuptools wheel pip-tools
-	rm -rf .tox
 
-install:  # install run-time requirements
-	pip install --upgrade -r requirements.txt -r requirements-dev.txt
-	pip install --editable .
+dev-install:  # install development requirements
+	pip install -r requirements-dev.txt
+	pip install --editable .[aws,tests]
 
-update: init update-deps install
+update: clean-pyc clean-tests init update-deps dev-install
 
 update-deps: # update dependancies
-	pip-compile --upgrade --output-file requirements.txt requirements.in
 	pip-compile --upgrade --output-file requirements-dev.txt requirements-dev.in
 
-clean-pyc: ## Remove python artifacts.
+clean-pyc: ## Remove python/mypy artifacts
+	find . -name '*.egg-info' -exec rm -rf {} +
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f  {} +
 	find . -name '__pycache__' -exec rm -rf {} +
 	find . -name '.mypy_cache' -exec rm -rf {} +
+
+clean-tests: ## Removes tox, coverage, and pytest artifacts
+	rm -rf .tox
+	rm -rf coverage_html_report
+	rm -rf .coverage
 	find . -name '.pytest_cache' -exec rm -rf {} +
+
+run-tests: ## Run tox on default python install
+	tox -e py

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,6 +3,4 @@ black
 mypy
 flake8
 pytest
-coverage
 tox
-moto[secretsmanager]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,9 +12,9 @@ attrs==21.2.0
     # via pytest
 black==21.5b1
     # via -r requirements-dev.in
-boto3==1.17.83
+boto3==1.17.84
     # via moto
-botocore==1.20.83
+botocore==1.20.84
     # via
     #   boto3
     #   moto

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,27 +12,10 @@ attrs==21.2.0
     # via pytest
 black==21.5b1
     # via -r requirements-dev.in
-boto3==1.17.84
-    # via moto
-botocore==1.20.84
-    # via
-    #   boto3
-    #   moto
-    #   s3transfer
-certifi==2020.12.5
-    # via requests
-cffi==1.14.5
-    # via cryptography
 cfgv==3.3.0
     # via pre-commit
-chardet==4.0.0
-    # via requests
 click==8.0.1
     # via black
-coverage==5.5
-    # via -r requirements-dev.in
-cryptography==3.4.7
-    # via moto
 distlib==0.3.1
     # via virtualenv
 filelock==3.0.12
@@ -43,26 +26,10 @@ flake8==3.9.2
     # via -r requirements-dev.in
 identify==2.2.6
     # via pre-commit
-idna==2.10
-    # via requests
 iniconfig==1.1.1
     # via pytest
-jinja2==3.0.1
-    # via moto
-jmespath==0.10.0
-    # via
-    #   boto3
-    #   botocore
-markupsafe==2.0.1
-    # via
-    #   jinja2
-    #   moto
 mccabe==0.6.1
     # via flake8
-more-itertools==8.8.0
-    # via moto
-moto[secretsmanager]==2.0.8
-    # via -r requirements-dev.in
 mypy-extensions==0.4.3
     # via
     #   black
@@ -89,37 +56,18 @@ py==1.10.0
     #   tox
 pycodestyle==2.7.0
     # via flake8
-pycparser==2.20
-    # via cffi
 pyflakes==2.3.1
     # via flake8
 pyparsing==2.4.7
     # via packaging
 pytest==6.2.4
     # via -r requirements-dev.in
-python-dateutil==2.8.1
-    # via
-    #   botocore
-    #   moto
-pytz==2021.1
-    # via moto
 pyyaml==5.4.1
     # via pre-commit
 regex==2021.4.4
     # via black
-requests==2.25.1
-    # via
-    #   moto
-    #   responses
-responses==0.13.3
-    # via moto
-s3transfer==0.4.2
-    # via boto3
 six==1.16.0
     # via
-    #   moto
-    #   python-dateutil
-    #   responses
     #   tox
     #   virtualenv
 toml==0.10.2
@@ -134,19 +82,7 @@ typed-ast==1.4.3
     # via mypy
 typing-extensions==3.10.0.0
     # via mypy
-urllib3==1.26.5
-    # via
-    #   botocore
-    #   requests
-    #   responses
 virtualenv==20.4.7
     # via
     #   pre-commit
     #   tox
-werkzeug==2.0.1
-    # via moto
-xmltodict==0.12.0
-    # via moto
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,0 @@
-boto3
-boto3-stubs[secretsmanager]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,25 +4,3 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-boto3-stubs[secretsmanager]==1.17.83
-    # via -r requirements.in
-boto3==1.17.83
-    # via -r requirements.in
-botocore==1.20.83
-    # via
-    #   boto3
-    #   s3transfer
-jmespath==0.10.0
-    # via
-    #   boto3
-    #   botocore
-mypy-boto3-secretsmanager==1.17.83
-    # via boto3-stubs
-python-dateutil==2.8.1
-    # via botocore
-s3transfer==0.4.2
-    # via boto3
-six==1.16.0
-    # via python-dateutil
-urllib3==1.26.5
-    # via botocore

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ exclude =
 aws =
     boto3
     boto3-stubs[secretsmanager]
+tests =
+    moto[secretsmanager]
 
 [mypy]
 check_untyped_defs = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,11 @@ where = src
 exclude =
     tests*
 
+[options.extras_require]
+aws =
+    boto3
+    boto3-stubs[secretsmanager]
+
 [mypy]
 check_untyped_defs = true
 disallow_any_generics = true

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ envlist = py36,py37,py38,py39
 skip_missing_interpreters = true
 
 [testenv]
-deps = -rrequirements.txt
+deps = .[aws,tests]
 commands =
-    pip install --upgrade pytest coverage moto[secretsmanager]
+    pip install --upgrade pytest coverage
     coverage erase
     coverage run -m pytest {posargs:tests}
-    coverage report --fail-under 95
+    coverage report --fail-under 95 -m
     coverage xml
     coverage html


### PR DESCRIPTION
- Do not require the boto3 library for standard module install
- Tests continue to require boto3 library
- Tests cover conditional of boto3 not being installed
  - `load_aws_store()` raises `NotImplementedError` directing to install boto3
  - `load()` silently skips call to aws loader
- Refactor of test code