### PR TITLE
Aws enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,11 @@ import sys
 
 from secretbox import SecretBox
 
-secrets = SecretBox()
+secrets = SecretBox(auto_load=True)
 
 
 def main() -> int:
     """Main function"""
-    secrets.load()
-
     my_sevice_password = secrets.get("SERVICE_PW")
     # More code
 
@@ -67,9 +65,11 @@ if __name__ == "__main__":
 
 **aws_sstore_name**
 - When provided, an attempt to load values from named AWS secrets manager will be made. Requires `aws_region` to be provided. Requires `boto3` and `boto3-stubs[secretsmanager]` to be installed
+- **Note**:  Can be provided with the `AWS_SSTORE_NAME` environment variable.
 
-**aws_region**
+**aws_region_name**
 - When provided, an attempt to load values from the given AWS secrets manager found in this region will be made. Requires `aws_sstore_name` to be provided. Requires `boto3` and `boto3-stubs[secretsmanager]` to be installed
+- **Note**:  Can be provided with the `AWS_REGION_NAME` environment variable.
 
 **auto_load**
 - If true, the `load()` method will be auto-exectued on initialization

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -44,7 +44,7 @@ packaging==21.0
     #   tox
 pathspec==0.9.0
     # via black
-platformdirs==2.1.0
+platformdirs==2.2.0
     # via virtualenv
 pluggy==0.13.1
     # via
@@ -78,7 +78,7 @@ toml==0.10.2
     #   pre-commit
     #   pytest
     #   tox
-tomli==1.1.0
+tomli==1.2.0
     # via black
 tox==3.24.0
     # via -r requirements-dev.in

--- a/src/secretbox/secretbox.py
+++ b/src/secretbox/secretbox.py
@@ -32,7 +32,7 @@ class SecretBox:
         self,
         filename: str = ".env",
         aws_sstore_name: Optional[str] = None,
-        aws_region: Optional[str] = None,
+        aws_region_name: Optional[str] = None,
         auto_load: bool = False,
     ) -> None:
         """
@@ -45,20 +45,22 @@ class SecretBox:
                 overriding the default behavior to load the `.env` from the
                 working directory
             aws_sstore_name : When provided, an attempt to load values from
-                named AWS secrets manager will be made. Requires `aws_region`
-                to be provided. Requires `boto3` and `boto3-stubs[secretsmanager]`
-                to be installed
-            aws_region : When provided, an attempt to load values from the given
-                AWS secrets manager found in this region will be made. Requires
-                `aws_sstore_name` to be provided. Requires `boto3` and
-                `boto3-stubs[secretsmanager]` to be installed
+                named AWS secrets manager will be made. Can be provided with
+                the `AWS_SSTORE_NAME` environment variable.
+                Requires `boto3` and `boto3-stubs[secretsmanager]` to be installed.
+            aws_region_name : When provided, an attempt to load values from the given
+                AWS secrets manager found in this region will be made. Can be provided
+                with the `AWS_REGION_NAME` environment variable.
+                Requires `boto3` and `boto3-stubs[secretsmanager]` to be installed
             auto_load : If true, the `load()` method will be auto-executed
 
         """
+        env_region = os.getenv("AWS_REGION_NAME")
+        env_sstore = os.getenv("AWS_SSTORE_NAME")
         self.filename: str = filename
         self.loaded_values: Dict[str, str] = {}
-        self.aws_region = aws_region
-        self.aws_sstore = aws_sstore_name
+        self.aws_region = env_region if aws_region_name is None else aws_region_name
+        self.aws_sstore = env_sstore if aws_sstore_name is None else aws_sstore_name
         if auto_load:
             self.load()
 

--- a/tests/aws_test.py
+++ b/tests/aws_test.py
@@ -77,3 +77,14 @@ def test_boto3_missing_import_catch() -> None:
         assert secretbox.boto3 is None
         _ = secretbox.SecretBox()
     importlib.reload(secretbox)
+
+
+def test_load_aws_from_env() -> None:
+    """Special case where AWS values are in environ already"""
+    sstore = "aws-store"
+    region = "us-east-1"
+    with patch.dict(os.environ, {"AWS_SSTORE_NAME": sstore, "AWS_REGION_NAME": region}):
+        secrets = SecretBox()
+
+        assert secrets.aws_sstore == sstore
+        assert secrets.aws_region == region

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def fixture_secretbox() -> Generator[secretbox.SecretBox, None, None]:
 @pytest.fixture(scope="function", name="secretbox_aws")
 def fixture_secretbox_aws() -> Generator[secretbox.SecretBox, None, None]:
     """Default instance of LoadEnv"""
-    yield secretbox.SecretBox(aws_region=TEST_REGION, aws_sstore_name=TEST_STORE)
+    yield secretbox.SecretBox(aws_region_name=TEST_REGION, aws_sstore_name=TEST_STORE)
 
 
 ##############################################################################


### PR DESCRIPTION
closes #12 

Adds:
`AWS_SSTORE_NAME` and `AWS_REGION_NAME` are pulled from existing environ variables if set when the class instance is created.  The keyword arguments for these values remains priority and will be used if provided.
Changes:
Class API: keyword argument `aws_region` renamed to `aws_region_name` for consistency 


This will allow the secret store location and name to be packaged in the deployment container/target as environment values and reduce the amount of values hardcoded.