### PR TITLE
Do not run load_aws if values are empty or None

### DIFF
--- a/src/secretbox/secretbox.py
+++ b/src/secretbox/secretbox.py
@@ -76,7 +76,7 @@ class SecretBox:
         """
         self.load_env_vars()
         self.load_env_file()
-        if boto3 is not None:
+        if boto3 is not None and (self.aws_region and self.aws_sstore):
             self.load_aws_store()
         self.push_to_environment()
 


### PR DESCRIPTION
This prevents the `load_aws()` call during `load()` or `auto_load=True`
if the values are empty or missing. In cases that boto3 is installed but
the secret store is not being used this will reduce load time.

closes #14 