### PR TITLE
Adjust test for coverage

### DIFF
--- a/tests/aws_test.py
+++ b/tests/aws_test.py
@@ -49,6 +49,9 @@ def test_load_aws_secrets(
 
     assert not secretbox.get(TEST_KEY_NAME)
     secretbox.load()
+    secretbox.load_env_vars()
+    secretbox.load_env_file()
+    secretbox.load_aws_store()
     assert secretbox.get(TEST_KEY_NAME) == expected
 
 


### PR DESCRIPTION
With an additional logic check to increase load times when boto3 is
available but no aws values are present we skipped testing edge cases.
This adjusts the test to directly call the loading methods, ensuring
even with initial logic we are handing edge cases in the internal
methods.