### PR TITLE
Add debug logging, optional flag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     rev: 3.9.2
     hooks:
       - id: flake8
-        args: [--max-line-length, "88"]
+        args: ["--max-line-length", "88", "--ignore", "E203"]
 
   # Type enforcement for Python
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/tests/secretbox_test.py
+++ b/tests/secretbox_test.py
@@ -1,5 +1,6 @@
 """Unit tests against secretbox.py"""
 import os
+from typing import Any
 from unittest.mock import patch
 
 from secretbox import SecretBox
@@ -55,3 +56,14 @@ def test_missing_key_is_empty(secretbox: SecretBox) -> None:
 def test_default_missing_key(secretbox: SecretBox) -> None:
     """Missing key? Return the provided default instead"""
     assert secretbox.get("BYWHATCHANCEWOULDTHISSEXIST", "Hello") == "Hello"
+
+
+def test_load_debug_flag(caplog: Any) -> None:
+    """Ensure logging is silentish"""
+    _ = SecretBox()
+
+    assert "Debug flag passed." not in caplog.text
+
+    _ = SecretBox(debug_flag=True)
+
+    assert "Debug flag passed." in caplog.text


### PR DESCRIPTION
Add `debug_flag` parameter for creating an instance of Secretbox. This
enables the class logger to `DEBUG` levels (normally `ERROR`). Any
output with values of loaded variables is truncated, only showing the
last one-fourth of the value.

Additionally, add E203 to `flake8` ignore list because we aren't going
to fight `black` for who is correct on where the `:` goes in a list
splice.