### PR TITLE
`.env` parsing update

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,11 @@ if __name__ == "__main__":
 Current format for the `.env` file supports strings only and is parsed in the following order:
 - Each seperate line is considered a new possible key/value set
 - Each set is delimted by the first `=` found
+- Leading `export` keyword is removed from key, case agnostic
 - Leading and trailing whitespace are removed
 - Matched leading/trailing single quotes or double quotes will be stripped from values (not keys).
 
-I'm open to suggestions on standards to follow here.
+I'm open to suggestions on standards to follow here. This is compiled from "crowd standard" and what is useful at the time.
 
 This `.env` example:
 ```conf
@@ -151,7 +152,7 @@ Will be parsed as:
 
 This `.env` example:
 ```conf
-PASSWORD = correct horse battery staple
+export PASSWORD = correct horse battery staple
 USER_NAME="not_admin"
 
 MESSAGE = '    Totally not an "admin" account logging in'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = secretbox
-version = 2.1.0
+version = 2.2.0
 description = A library that offers a simple method of loading and accessing environmental variables and `.env` file values.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,8 +36,9 @@ ENV_FILE_CONTENTS = [
     "PASSWORD = correct horse battery staple",
     'USER_NAME="not_admin"',
     "MESSAGE = '    Totally not an \"admin\" account logging in'",
-    "SINGLE_QUOTES = 'test'",
+    "  SINGLE_QUOTES = 'test'",
     "NESTED_QUOTES = \"'Double your quotes, double your fun'\"",
+    'eXport SHELL_COMPATIBLE = "well, that happened"',
 ]
 
 ENV_FILE_EXPECTED = {
@@ -49,6 +50,7 @@ ENV_FILE_EXPECTED = {
     "MESSAGE": '    Totally not an "admin" account logging in',
     "SINGLE_QUOTES": "test",
     "NESTED_QUOTES": "'Double your quotes, double your fun'",
+    "SHELL_COMPATIBLE": "well, that happened",
 }
 
 ##############################################################################


### PR DESCRIPTION
This change allows, and strips, the `export` keyword from a loaded
`.env` file's key. This should allow the `.env` file to be loaded into
the environment from the shell and from SecretBox.