### PR TITLE
Filter response body from botocore parsers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = secretbox
-version = 2.2.0
+version = 2.2.1
 description = A library that offers a simple method of loading and accessing environmental variables and `.env` file values.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ import pytest
 from boto3.session import Session
 from moto.secretsmanager import mock_secretsmanager
 from mypy_boto3_secretsmanager.client import SecretsManagerClient
-from secretbox.awssecret_loader import AWSSecretLoader
 from secretbox.envfile_loader import EnvFileLoader
 from secretbox.environ_loader import EnvironLoader
 from secretbox.secretbox import SecretBox
@@ -70,14 +69,6 @@ def fixtures_envfile_loader() -> Generator[EnvFileLoader, None, None]:
 def fixture_environ_loader() -> Generator[EnvironLoader, None, None]:
     """A fixture because this is what we do"""
     loader = EnvironLoader()
-    assert not loader.loaded_values
-    yield loader
-
-
-@pytest.fixture(scope="function", name="awssecret_loader")
-def fixtures_awssecret_loader() -> Generator[AWSSecretLoader, None, None]:
-    """Create a fixture to test with"""
-    loader = AWSSecretLoader()
     assert not loader.loaded_values
     yield loader
 


### PR DESCRIPTION
botocore.parsers will display the entire response body in a `DEBUG`
level log. As this can include secrets/tokens that we do not want in
console output (or cloudwatch) we add a filter to `botocore.parsers` and
redact the secrets. This filter is removed in a `finally` block,
hopefully leaving the enviornment unpolluted.

closes #44 