### PR TITLE
Test cleanup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,25 +1,11 @@
 """Global fixtures"""
-import json
 import os
 import tempfile
 from typing import Generator
 from unittest.mock import patch
 
 import pytest
-from boto3.session import Session
-from moto.secretsmanager import mock_secretsmanager
-from moto.ssm import mock_ssm
-from mypy_boto3_secretsmanager.client import SecretsManagerClient
-from mypy_boto3_ssm.client import SSMClient
 
-TEST_KEY_NAME = "TEST_KEY"
-TEST_VALUE = "abcdefg"
-TEST_STORE = "my_store"
-TEST_STORE2 = "my_store2"
-TEST_STORE3 = "my_store3"
-TEST_REGION = "us-east-1"
-TEST_PATH = "/my/parameter/prefix/"
-TEST_LIST = ",".join([TEST_VALUE, TEST_VALUE, TEST_VALUE])
 
 AWS_ENV_KEYS = [
     "AWS_ACCESS_KEY",
@@ -68,13 +54,8 @@ def mock_env_file() -> Generator[str, None, None]:
         os.remove(path)
 
 
-##############################################################################
-# AWS Fixtures
-##############################################################################
-
-
-@pytest.fixture(scope="function", name="mask_aws_creds")
-def fixture_mask_aws_creds() -> Generator[None, None, None]:
+@pytest.fixture
+def mask_aws_creds() -> Generator[None, None, None]:
     """Mask local AWS creds to avoid moto calling out"""
     with patch.dict(os.environ):
         for key in AWS_ENV_KEYS:
@@ -82,56 +63,10 @@ def fixture_mask_aws_creds() -> Generator[None, None, None]:
         yield None
 
 
-@pytest.fixture(scope="function", name="remove_aws_creds")
-def fixture_remove_aws_creds() -> Generator[None, None, None]:
+@pytest.fixture
+def remove_aws_creds() -> Generator[None, None, None]:
     """Removes AWS cresd from environment"""
     with patch.dict(os.environ):
         for key in AWS_ENV_KEYS:
             os.environ.pop(key, None)
         yield None
-
-
-@pytest.fixture(scope="function", name="secretsmanager")
-def fixture_secretsmanager() -> Generator[SecretsManagerClient, None, None]:
-    """Populate mock secretsmanager with TEST_SECRET_KEY in us-east-1"""
-    secret_values = json.dumps({TEST_KEY_NAME: TEST_VALUE})
-
-    with mock_secretsmanager():
-        session = Session()
-        client = session.client(
-            service_name="secretsmanager",
-            region_name=TEST_REGION,
-        )
-        client.create_secret(Name=TEST_STORE, SecretString=secret_values)
-
-        yield client
-
-
-@pytest.fixture(scope="function", name="parameterstore")
-def fixture_parameterstore() -> Generator[SSMClient, None, None]:
-    """Populate mock parameterstore with two values we can load via prefix"""
-
-    with mock_ssm():
-        session = Session()
-        client = session.client(
-            service_name="ssm",
-            region_name=TEST_REGION,
-        )
-        client.put_parameter(
-            Name=f"{TEST_PATH}{TEST_STORE}", Value=TEST_VALUE, Type="String"
-        )
-        # Load enough so pagination can be tested
-        for x in range(1, 31):
-            client.put_parameter(
-                Name=f"{TEST_PATH}{TEST_STORE}/{x}", Value=TEST_VALUE, Type="String"
-            )
-        client.put_parameter(
-            Name=f"{TEST_PATH}{TEST_STORE2}", Value=TEST_VALUE, Type="SecureString"
-        )
-        client.put_parameter(
-            Name=f"{TEST_PATH}{TEST_STORE3}",
-            Value=TEST_LIST,
-            Type="StringList",
-        )
-
-        yield client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,6 @@ from moto.secretsmanager import mock_secretsmanager
 from moto.ssm import mock_ssm
 from mypy_boto3_secretsmanager.client import SecretsManagerClient
 from mypy_boto3_ssm.client import SSMClient
-from secretbox.envfile_loader import EnvFileLoader
-from secretbox.environ_loader import EnvironLoader
-from secretbox.secretbox import SecretBox
 
 TEST_KEY_NAME = "TEST_KEY"
 TEST_VALUE = "abcdefg"
@@ -58,42 +55,9 @@ ENV_FILE_EXPECTED = {
     "SHELL_COMPATIBLE": "well, that happened",
 }
 
-##############################################################################
-# Base fixtures
-##############################################################################
 
-
-@pytest.fixture(scope="function", name="envfile_loader")
-def fixtures_envfile_loader() -> Generator[EnvFileLoader, None, None]:
-    """Create us a fixture"""
-    loader = EnvFileLoader()
-    assert not loader.loaded_values
-    yield loader
-
-
-@pytest.fixture(scope="function", name="environ_loader")
-def fixture_environ_loader() -> Generator[EnvironLoader, None, None]:
-    """A fixture because this is what we do"""
-    loader = EnvironLoader()
-    assert not loader.loaded_values
-    yield loader
-
-
-@pytest.fixture(scope="function", name="secretbox")
-def fixture_secretbox() -> Generator[SecretBox, None, None]:
-    """Default instance of LoadEnv"""
-    secrets = SecretBox()
-    assert not secrets.loaded_values
-    yield secrets
-
-
-##############################################################################
-# Mocking .env file loading
-##############################################################################
-
-
-@pytest.fixture(scope="function", name="mock_env_file")
-def fixture_mock_env_file() -> Generator[str, None, None]:
+@pytest.fixture
+def mock_env_file() -> Generator[str, None, None]:
     """Builds and returns filename of a mock .env file"""
     try:
         file_desc, path = tempfile.mkstemp()

--- a/tests/envfile_loader_test.py
+++ b/tests/envfile_loader_test.py
@@ -1,7 +1,18 @@
 """Unit tests for .env file loader"""
+from typing import Generator
+
+import pytest
 from secretbox.envfile_loader import EnvFileLoader
 
 from tests.conftest import ENV_FILE_EXPECTED
+
+
+@pytest.fixture
+def envfile_loader() -> Generator[EnvFileLoader, None, None]:
+    """Create us a fixture"""
+    loader = EnvFileLoader()
+    assert not loader.loaded_values
+    yield loader
 
 
 def test_load_env_file(mock_env_file: str, envfile_loader: EnvFileLoader) -> None:

--- a/tests/environ_loader_test.py
+++ b/tests/environ_loader_test.py
@@ -1,15 +1,35 @@
 """Simple test to ensure we read environ"""
 import os
+from typing import Generator
 from unittest.mock import patch
 
+import pytest
 from secretbox.environ_loader import EnvironLoader
 
-from tests.conftest import ENV_FILE_EXPECTED
+MOCK_ENV = {
+    "SECRETBOX_TEST_PROJECT_ENVIRONMENT": "sandbox",
+    "VALID": "=",
+    "SUPER_SECRET": "12345",
+    "PASSWORD": "correct horse battery staple",
+    "USER_NAME": "not_admin",
+    "MESSAGE": '    Totally not an "admin" account logging in',
+    "SINGLE_QUOTES": "test",
+    "NESTED_QUOTES": "'Double your quotes, double your fun'",
+    "SHELL_COMPATIBLE": "well, that happened",
+}
+
+
+@pytest.fixture
+def environ_loader() -> Generator[EnvironLoader, None, None]:
+    """A fixture because this is what we do"""
+    loader = EnvironLoader()
+    assert not loader.loaded_values
+    yield loader
 
 
 def test_load_env_vars(environ_loader: EnvironLoader) -> None:
     """Load and confirm values from environ"""
-    with patch.dict(os.environ, ENV_FILE_EXPECTED):
+    with patch.dict(os.environ, MOCK_ENV):
         environ_loader.load_values()
-        for key, value in ENV_FILE_EXPECTED.items():
+        for key, value in MOCK_ENV.items():
             assert environ_loader.loaded_values.get(key) == value, f"{key}, {value}"

--- a/tests/secretbox_test.py
+++ b/tests/secretbox_test.py
@@ -1,12 +1,21 @@
 """Unit tests against secretbox.py"""
 import os
 from typing import Any
+from typing import Generator
 from unittest.mock import patch
 
 import pytest
 from secretbox import SecretBox
 
 from tests.conftest import ENV_FILE_EXPECTED
+
+
+@pytest.fixture
+def secretbox() -> Generator[SecretBox, None, None]:
+    """Default instance of LoadEnv"""
+    secrets = SecretBox()
+    assert not secrets.loaded_values
+    yield secrets
 
 
 def test_load_from_with_unknown(secretbox: SecretBox, mock_env_file: str) -> None:


### PR DESCRIPTION
These changes move most of the contents of `conftest.py` into the appropriate testing module. It also removes the `scope="function"` and `name=[name]` parameters of the `@pytest.fixture` decorator as these are the default behavior of the decorator. Now that secretbox has been refactored into loaders, it no longer makes sense to hold loader specific fixtures in the `conftest.py` file.

3afd9c6 conftest cleanup
779130e awsparameterstore_loader test cleanup
6180208 awssecret_loader test cleanup
688807a secretbox tests cleanup
a7f62d8 envrion_loader cleanup
0c974be envfile_loader clean up