### PR TITLE
Softer import conditions and logging enhancements

### DIFF
--- a/src/secretbox/awssecret_loader.py
+++ b/src/secretbox/awssecret_loader.py
@@ -15,9 +15,12 @@ try:
     import boto3
     from botocore.exceptions import ClientError
     from botocore.exceptions import NoCredentialsError
-    from mypy_boto3_secretsmanager.client import SecretsManagerClient
 except ImportError:
     boto3 = None
+
+try:
+    from mypy_boto3_secretsmanager.client import SecretsManagerClient
+except ImportError:
     SecretsManagerClient = None
 
 from secretbox.loader import Loader

--- a/tests/awsparameterstore_loader_test.py
+++ b/tests/awsparameterstore_loader_test.py
@@ -77,6 +77,14 @@ def test_boto3_missing_import_catch() -> None:
     importlib.reload(ssm_loader_module)
 
 
+def test_boto3_stubs_missing_import_catch() -> None:
+    with patch.dict(sys.modules, {"mypy_boto3_ssm.client": None}):
+        importlib.reload(ssm_loader_module)
+        assert ssm_loader_module.SSMClient is None
+    # Reload after test to avoid polution
+    importlib.reload(ssm_loader_module)
+
+
 @pytest.mark.parametrize(
     ("prefix", "region", "expectedCnt"),
     (

--- a/tests/awssecret_loader_test.py
+++ b/tests/awssecret_loader_test.py
@@ -105,10 +105,17 @@ def test_boto3_stubs_not_installed(awssecret_loader: AWSSecretLoader) -> None:
 
 
 def test_boto3_missing_import_catch() -> None:
-    """Reload loadenv without boto3"""
     with patch.dict(sys.modules, {"boto3": None}):
         importlib.reload(awssecret_loader_module)
         assert awssecret_loader_module.boto3 is None
+    # Reload after test to avoid polution
+    importlib.reload(awssecret_loader_module)
+
+
+def test_boto3_stubs_missing_import_catch() -> None:
+    with patch.dict(sys.modules, {"mypy_boto3_secretsmanager.client": None}):
+        importlib.reload(awssecret_loader_module)
+        assert awssecret_loader_module.SecretsManagerClient is None
     # Reload after test to avoid polution
     importlib.reload(awssecret_loader_module)
 


### PR DESCRIPTION
Adds more forgiving import requirements for deployments to AWS lambdas. Enhances logging in parameter store loader to focus on `ClientError`.

0d80b24 Allow `boto3-stubs` to be optional for parameter store
82d1abb Allow `boto3-stubs` to be optional for secretmanager