### PR TITLE
Refactor AWS loaders

### DIFF
--- a/src/secretbox/aws_loader.py
+++ b/src/secretbox/aws_loader.py
@@ -1,0 +1,75 @@
+"""
+Super class for AWS secrets manager and parameter store loaders
+
+Author  : Preocts <preocts#8196>
+Git Repo: https://github.com/Preocts/secretbox
+"""
+import logging
+import os
+from typing import Any
+from typing import Optional
+
+from secretbox.loader import Loader
+
+
+class AWSLoader(Loader):
+    """Super class with mutual methods of AWS loaders, inherits Loader"""
+
+    logger = logging.getLogger(__name__)
+    # Override filter_secrets to False to allow full debug logging of boto3.parsers
+    filter_secrets = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.aws_sstore: Optional[str] = None
+        self.aws_region: Optional[str] = None
+
+    def get_aws_client(self) -> Any:
+        """Returns correct AWS client for low-level API requests"""
+        # NOTE: Override in client specific implementation
+        raise NotImplementedError  # pragma: no cover
+
+    def populate_region_store_names(self, **kwargs: Any) -> None:
+        """Populates store/region name"""
+        kw_sstore = kwargs.get("aws_sstore_name")
+        kw_region = kwargs.get("aws_region_name")
+        os_sstore = os.getenv("AWS_SSTORE_NAME")
+        os_region = os.getenv("AWS_REGION_NAME", os.getenv("AWS_REGION"))  # Lambda's
+
+        # Use the keyword over the os, default to None
+        self.aws_sstore = kw_sstore if kw_sstore is not None else os_sstore
+        self.aws_region = kw_region if kw_region is not None else os_region
+        self.logger.debug("Using store name '%s'", self.aws_sstore)
+        self.logger.debug("Using region name '%s'", self.aws_region)
+
+    def log_aws_error(self, err: Any) -> None:
+        """Verbose AWS error log output. If not an AWS error, generic repl of err"""
+        if (
+            hasattr(err, "response")  # assert attribute exists or fail early
+            and "Error" in err.response
+            and "ResponseMetadata" in err.response
+        ):
+            self.logger.error(
+                "%s - %s (%s)",
+                err.response["Error"]["Code"],
+                err.response["Error"]["Message"],
+                err.response["ResponseMetadata"],
+            )
+        else:
+            self.logger.error("Unexpected error occurred: '%s'", str(err))
+
+    @staticmethod
+    def secrets_filter(record: logging.LogRecord) -> bool:
+        """
+        Hide botocore.parsers responses which include decrypted secrets
+
+        https://github.com/boto/botocore/issues/1211#issuecomment-327799341
+        """
+        if record.levelno > logging.DEBUG or not AWSLoader.filter_secrets:
+            return True
+        if "body" in record.msg or "headers" in record.msg:
+            if isinstance(record.args, dict):
+                record.args = {key: "REDACTED" for key in record.args}
+            else:
+                record.args = ("REDACTED",) * len(record.args or [])
+        return True

--- a/src/secretbox/awsparameterstore_loader.py
+++ b/src/secretbox/awsparameterstore_loader.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any
 from typing import Optional
 
-from secretbox.awssecret_loader import AWSSecretLoader
+from secretbox.aws_loader import AWSLoader
 
 try:
     import boto3
@@ -21,7 +21,7 @@ except ImportError:
     SSMClient = None
 
 
-class AWSParameterStore(AWSSecretLoader):
+class AWSParameterStore(AWSLoader):
     """Load secrets from an AWS Parameter Store"""
 
     def __init__(self) -> None:
@@ -45,7 +45,7 @@ class AWSParameterStore(AWSSecretLoader):
             self.logger.warning("Missing parameter name")
             return True  # this isn't a failure on our part
 
-        aws_client = self.connect_aws_ssm_client()
+        aws_client = self.get_aws_client()
         if aws_client is None:
             self.logger.error("Invalid SSM client")
             return False
@@ -80,7 +80,7 @@ class AWSParameterStore(AWSSecretLoader):
                     break
 
         except ClientError as err:
-            self._log_client_error(err)
+            self.log_aws_error(err)
             return False
 
         finally:
@@ -92,7 +92,7 @@ class AWSParameterStore(AWSSecretLoader):
         )
         return True
 
-    def connect_aws_ssm_client(self) -> Optional[SSMClient]:
+    def get_aws_client(self) -> Optional[SSMClient]:
         """Make the connection"""
 
         if self.aws_region is None:
@@ -106,5 +106,5 @@ class AWSParameterStore(AWSSecretLoader):
                 region_name=self.aws_region,
             )
         except ClientError as err:
-            self._log_client_error(err)
+            self.log_aws_error(err)
             return None

--- a/tests/aws_loader_test.py
+++ b/tests/aws_loader_test.py
@@ -1,0 +1,81 @@
+"""Unit tests for aws loader"""
+import logging
+import os
+from typing import Any
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+from secretbox.aws_loader import AWSLoader
+
+
+@pytest.fixture
+def awsloader() -> Generator[AWSLoader, None, None]:
+    """Create a fixture to test with"""
+    loader = AWSLoader()
+    assert not loader.loaded_values
+    yield loader
+
+
+def test_populate_region_store_names_none(awsloader: AWSLoader) -> None:
+    """Nothing provided"""
+    with patch.dict(os.environ):
+        os.environ.pop("AWS_SSTORE_NAME", None)
+        os.environ.pop("AWS_REGION_NAME", None)
+        awsloader.populate_region_store_names()
+        assert awsloader.aws_sstore is None
+        assert awsloader.aws_region is None
+
+
+def test_populate_region_store_names_os(awsloader: AWSLoader) -> None:
+    """values in environ"""
+    with patch.dict(os.environ):
+        os.environ["AWS_SSTORE_NAME"] = "MockStore"
+        os.environ["AWS_REGION_NAME"] = "MockRegion"
+        awsloader.populate_region_store_names()
+        assert awsloader.aws_sstore == "MockStore"
+        assert awsloader.aws_region == "MockRegion"
+
+
+def test_populate_region_store_names_kw(awsloader: AWSLoader) -> None:
+    """values in environ but keywords given"""
+    with patch.dict(os.environ):
+        os.environ["AWS_SSTORE_NAME"] = "MockStore"
+        os.environ["AWS_REGION_NAME"] = "MockRegion"
+        awsloader.populate_region_store_names(
+            aws_sstore_name="NewStore",
+            aws_region_name="NewRegion",
+        )
+        assert awsloader.aws_sstore == "NewStore"
+        assert awsloader.aws_region == "NewRegion"
+
+
+def test_secret_filter(caplog: Any) -> None:
+    logger = logging.getLogger("secrets")
+    logger.addFilter(AWSLoader.secrets_filter)
+    logger.setLevel("DEBUG")
+    secret_dict = {"allYour": "Passwords"}
+    secret_tuple = ("I am a plain-text secrets",)
+    secret_string = "Your password is 12345"
+
+    logger.debug("Reponse body: %s", secret_dict)
+    logger.debug("Reponse body: %s", secret_tuple)
+    logger.debug("Reponse body: %s", secret_string)
+    logger.debug("Response body:")
+    logger.debug("Standard log")
+
+    logger.info("Safe Info")
+
+    assert "Passwords" not in caplog.text
+    assert "plain-text" not in caplog.text
+    assert "12345" not in caplog.text
+    assert "Standard log" in caplog.text
+    assert "Safe Info" in caplog.text
+
+
+def test_log_aws_error_with_nonaws_error(awsloader: AWSLoader, caplog: Any) -> None:
+    try:
+        raise Exception("Manufactored exception")
+    except Exception as err:
+        awsloader.log_aws_error(err)
+    assert "Manufactored exception" in caplog.text

--- a/tests/awsparameterstore_loader_test.py
+++ b/tests/awsparameterstore_loader_test.py
@@ -116,17 +116,3 @@ def test_count_parameters(
 
     # loaded the proper number of parameters
     assert len(loader.loaded_values) == expectedCnt
-
-
-@pytest.mark.usefixtures("mask_aws_creds", "parameterstore")
-def test_parameter_values(
-    loader: AWSParameterStore,
-) -> None:
-    """compare parameters from mocked loader to what we put in there"""
-    # loading succeeded
-    assert loader.load_values(aws_sstore_name=TEST_PATH, aws_region_name=TEST_REGION)
-
-    # both our parameters exist and have the expected value
-    assert loader.loaded_values.get(TEST_STORE) == TEST_VALUE
-    assert loader.loaded_values.get(TEST_STORE2) == TEST_VALUE
-    assert loader.loaded_values.get(TEST_STORE3) == TEST_LIST

--- a/tests/awsparameterstore_loader_test.py
+++ b/tests/awsparameterstore_loader_test.py
@@ -116,3 +116,17 @@ def test_count_parameters(
 
     # loaded the proper number of parameters
     assert len(loader.loaded_values) == expectedCnt
+
+
+@pytest.mark.usefixtures("mask_aws_creds", "parameterstore")
+def test_parameter_values(
+    loader: AWSParameterStore,
+) -> None:
+    """compare parameters from mocked loader to what we put in there"""
+    # loading succeeded
+    assert loader.load_values(aws_sstore_name=TEST_PATH, aws_region_name=TEST_REGION)
+
+    # both our parameters exist and have the expected value
+    assert loader.loaded_values.get(TEST_STORE) == TEST_VALUE
+    assert loader.loaded_values.get(TEST_STORE2) == TEST_VALUE
+    assert loader.loaded_values.get(TEST_STORE3) == TEST_LIST

--- a/tests/awssecret_loader_test.py
+++ b/tests/awssecret_loader_test.py
@@ -1,8 +1,6 @@
 """Unit tests for aws secrect manager interactions"""
 import importlib
 import json
-import logging
-import os
 import sys
 from typing import Any
 from typing import Generator
@@ -118,59 +116,3 @@ def test_boto3_stubs_missing_import_catch() -> None:
         assert awssecret_loader_module.SecretsManagerClient is None
     # Reload after test to avoid polution
     importlib.reload(awssecret_loader_module)
-
-
-def test_populate_region_store_names_none(awssecret_loader: AWSSecretLoader) -> None:
-    """Nothing provided"""
-    with patch.dict(os.environ):
-        os.environ.pop("AWS_SSTORE_NAME", None)
-        os.environ.pop("AWS_REGION_NAME", None)
-        awssecret_loader.populate_region_store_names()
-        assert awssecret_loader.aws_sstore is None
-        assert awssecret_loader.aws_region is None
-
-
-def test_populate_region_store_names_os(awssecret_loader: AWSSecretLoader) -> None:
-    """values in environ"""
-    with patch.dict(os.environ):
-        os.environ["AWS_SSTORE_NAME"] = "MockStore"
-        os.environ["AWS_REGION_NAME"] = "MockRegion"
-        awssecret_loader.populate_region_store_names()
-        assert awssecret_loader.aws_sstore == "MockStore"
-        assert awssecret_loader.aws_region == "MockRegion"
-
-
-def test_populate_region_store_names_kw(awssecret_loader: AWSSecretLoader) -> None:
-    """values in environ but keywords given"""
-    with patch.dict(os.environ):
-        os.environ["AWS_SSTORE_NAME"] = "MockStore"
-        os.environ["AWS_REGION_NAME"] = "MockRegion"
-        awssecret_loader.populate_region_store_names(
-            aws_sstore_name="NewStore",
-            aws_region_name="NewRegion",
-        )
-        assert awssecret_loader.aws_sstore == "NewStore"
-        assert awssecret_loader.aws_region == "NewRegion"
-
-
-def test_secret_filter(caplog: Any) -> None:
-    logger = logging.getLogger("secrets")
-    logger.addFilter(AWSSecretLoader.secrets_filter)
-    logger.setLevel("DEBUG")
-    secret_dict = {"allYour": "Passwords"}
-    secret_tuple = ("I am a plain-text secrets",)
-    secret_string = "Your password is 12345"
-
-    logger.debug("Reponse body: %s", secret_dict)
-    logger.debug("Reponse body: %s", secret_tuple)
-    logger.debug("Reponse body: %s", secret_string)
-    logger.debug("Response body:")
-    logger.debug("Standard log")
-
-    logger.info("Safe Info")
-
-    assert "Passwords" not in caplog.text
-    assert "plain-text" not in caplog.text
-    assert "12345" not in caplog.text
-    assert "Standard log" in caplog.text
-    assert "Safe Info" in caplog.text


### PR DESCRIPTION
This change moves all mutual classes used by secrets manager loader and
parameter store loader into a superclass to be used by both. This
simplifies testing and sharing of methods.

4b9d110 Restore test: incorrectly removed
b6edba2 Remove duplicate tests with refactor
b436ac9 Refactor to use new aws_loader superclass
7793d7a Refactor mutual methods into superclass for AWS loaders