### PR TITLE
Remove moto testing framework, replace with botocore Stubber

### DIFF
--- a/tests/awssecret_loader_test.py
+++ b/tests/awssecret_loader_test.py
@@ -2,37 +2,69 @@
 import importlib
 import json
 import sys
+from datetime import datetime
 from typing import Any
 from typing import Generator
 from unittest.mock import patch
 
+import botocore.client
+import botocore.session
 import pytest
-from boto3.session import Session
-from moto.secretsmanager import mock_secretsmanager
-from mypy_boto3_secretsmanager.client import SecretsManagerClient
+from botocore.client import BaseClient
+from botocore.stub import Stubber
 from secretbox import awssecret_loader as awssecret_loader_module
 from secretbox.awssecret_loader import AWSSecretLoader
 
 TEST_KEY_NAME = "TEST_KEY"
 TEST_VALUE = "abcdefg"
 TEST_STORE = "my_store"
+TEST_STORE_INVALID = "store_not_found"
 TEST_REGION = "us-east-1"
 
 
 @pytest.fixture
-def secretsmanager() -> Generator[SecretsManagerClient, None, None]:
-    """Populate mock secretsmanager with TEST_SECRET_KEY in us-east-1"""
+def mockclient() -> Generator[BaseClient, None, None]:
+    """
+    Mocks `get_secret_value` for AWS client.
+
+    Has two responses in order:
+        - Valid response for SecretId=TEST_STORE
+        - ClientError response for SecretId=TEST_STORE_INVALID
+
+    """
     secret_values = json.dumps({TEST_KEY_NAME: TEST_VALUE})
 
-    with mock_secretsmanager():
-        session = Session()
-        client = session.client(
-            service_name="secretsmanager",
-            region_name=TEST_REGION,
-        )
-        client.create_secret(Name=TEST_STORE, SecretString=secret_values)
+    # Create our mock secretstore response
+    valid_response = {
+        "ARN": f"arn:aws:secretsmanager:{TEST_REGION}:123456789012:{TEST_STORE}",
+        "Name": TEST_STORE,
+        "VersionId": "12345678901234567890123456789012",
+        "SecretBinary": b"",
+        "SecretString": secret_values,
+        "VersionStages": ["mock_stage"],
+        "CreatedDate": datetime(2021, 1, 17),
+    }
 
-        yield client
+    # Create mock secretstore session
+    session = botocore.session.get_session().create_client(
+        service_name="secretsmanager",
+        region_name=TEST_REGION,
+    )
+
+    with Stubber(session) as stubber:
+        stubber.add_response(
+            method="get_secret_value",
+            service_response=valid_response,
+            expected_params={"SecretId": TEST_STORE},
+        )
+        stubber.add_client_error(
+            method="get_secret_value",
+            service_error_code="ResourceNotFoundException",
+            service_message="Mock secret not found",
+            http_status_code=404,
+            expected_params={"SecretId": TEST_STORE_INVALID},
+        )
+        yield session
 
 
 @pytest.fixture
@@ -46,7 +78,6 @@ def awssecret_loader() -> Generator[AWSSecretLoader, None, None]:
 @pytest.mark.usefixtures("remove_aws_creds")
 def test_load_aws_no_credentials(awssecret_loader: AWSSecretLoader) -> None:
     """Cause a NoCredentialsError to be handled"""
-    assert not awssecret_loader.loaded_values
     awssecret_loader.load_values(
         aws_sstore_name=TEST_STORE,
         aws_region_name=TEST_REGION,
@@ -54,31 +85,61 @@ def test_load_aws_no_credentials(awssecret_loader: AWSSecretLoader) -> None:
     assert not awssecret_loader.loaded_values
 
 
-@pytest.mark.parametrize(
-    ("store", "region", "expected"),
-    (
-        (TEST_STORE, TEST_REGION, TEST_VALUE),
-        (TEST_STORE, None, None),
-        (None, TEST_REGION, None),
-        (None, None, None),
-        ("store/not/found", TEST_REGION, None),
-        (TEST_STORE, "", None),
-    ),
-)
-@pytest.mark.usefixtures("mask_aws_creds", "secretsmanager")
-def test_load_aws_secrets(
+@pytest.mark.usefixtures("remove_aws_creds")
+def test_load_aws_no_secret_store_defined(awssecret_loader: AWSSecretLoader) -> None:
+    awssecret_loader.load_values(
+        aws_sstore_name=None,
+        aws_region_name=TEST_REGION,
+    )
+    assert not awssecret_loader.loaded_values
+
+
+def test_load_aws_client_no_region(
     awssecret_loader: AWSSecretLoader,
-    store: str,
-    region: str,
-    expected: Any,
+    caplog: Any,
+) -> None:
+    with patch.object(awssecret_loader, "get_aws_client", return_value=None):
+        assert not awssecret_loader.load_values(
+            aws_sstore_name=TEST_STORE,
+            aws_region_name=TEST_REGION,
+        )
+    assert "Invalid secrets manager client" in caplog.text
+
+
+@pytest.mark.usefixtures("remove_aws_creds")
+def test_get_client_without_region(
+    awssecret_loader: AWSSecretLoader,
+    caplog: Any,
+) -> None:
+    awssecret_loader.aws_region = None
+    result = awssecret_loader.get_aws_client()
+    assert result is None
+    assert "No valid AWS region" in caplog.text
+
+
+def test_load_aws_secrets_valid_store_and_invalid_store(
+    awssecret_loader: AWSSecretLoader,
+    mockclient: BaseClient,
 ) -> None:
     """Load a secret from mocked AWS secret server"""
-    assert not awssecret_loader.loaded_values.get(TEST_KEY_NAME)
-    awssecret_loader.load_values(aws_sstore_name=store, aws_region_name=region)
-    assert awssecret_loader.loaded_values.get(TEST_KEY_NAME) == expected
+    with patch.object(awssecret_loader, "get_aws_client", return_value=mockclient):
+
+        # Test valid response
+        awssecret_loader.load_values(
+            aws_sstore_name=TEST_STORE,
+            aws_region_name=TEST_REGION,
+        )
+        assert awssecret_loader.loaded_values.get(TEST_KEY_NAME) == TEST_VALUE
+
+        # Reset and test invalid response
+        awssecret_loader.loaded_values = {}
+        awssecret_loader.load_values(
+            aws_sstore_name=TEST_STORE_INVALID,
+            aws_region_name=TEST_REGION,
+        )
+        assert awssecret_loader.loaded_values.get(TEST_KEY_NAME) is None
 
 
-@pytest.mark.usefixtures("mask_aws_creds", "secretsmanager")
 def test_boto3_not_installed_auto_load(awssecret_loader: AWSSecretLoader) -> None:
     """Skip loading AWS secrets manager if no boto3"""
     with patch.object(awssecret_loader_module, "boto3", None):
@@ -90,16 +151,19 @@ def test_boto3_not_installed_auto_load(awssecret_loader: AWSSecretLoader) -> Non
         assert not awssecret_loader.loaded_values
 
 
-@pytest.mark.usefixtures("mask_aws_creds", "secretsmanager")
-def test_boto3_stubs_not_installed(awssecret_loader: AWSSecretLoader) -> None:
+def test_boto3_stubs_not_installed(
+    awssecret_loader: AWSSecretLoader,
+    mockclient: BaseClient,
+) -> None:
     """Continue loading AWS secrets manager without boto3-stubs"""
-    with patch.object(awssecret_loader_module, "SecretsManagerClient", None):
-        assert not awssecret_loader.loaded_values
-        awssecret_loader.load_values(
-            aws_sstore_name=TEST_STORE,
-            aws_region_name=TEST_REGION,
-        )
-        assert awssecret_loader.loaded_values
+    with patch.object(awssecret_loader, "get_aws_client", return_value=mockclient):
+        with patch.object(awssecret_loader_module, "SecretsManagerClient", None):
+            assert not awssecret_loader.loaded_values
+            awssecret_loader.load_values(
+                aws_sstore_name=TEST_STORE,
+                aws_region_name=TEST_REGION,
+            )
+            assert awssecret_loader.loaded_values
 
 
 def test_boto3_missing_import_catch() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def mock_env_file() -> Generator[str, None, None]:
         os.remove(path)
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mask_aws_creds() -> Generator[None, None, None]:
     """Mask local AWS creds to avoid moto calling out"""
     with patch.dict(os.environ):


### PR DESCRIPTION
No API changes, only test changes.  Begins work of #57 

a2102c9 Remove moto testing framework, replace with botocore Stubber
1c83ddd Auto use AWS cred masking fixture