### PR TITLE
Remove importlib from tests

### DIFF
--- a/tests/awsparameterstore_loader_base_test.py
+++ b/tests/awsparameterstore_loader_base_test.py
@@ -1,0 +1,31 @@
+"""Unit tests for aws parameter store interactions without boto3"""
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+from secretbox import awsparameterstore_loader as ssm_loader_module
+from secretbox.awsparameterstore_loader import AWSParameterStore
+
+TEST_PATH = "/my/parameter/prefix/"
+TEST_REGION = "us-east-1"
+
+
+@pytest.fixture
+def loader() -> Generator[AWSParameterStore, None, None]:
+    """Pass an unaltered loader"""
+    loader = AWSParameterStore()
+    yield loader
+
+
+def test_empty_values_on_init(loader: AWSParameterStore) -> None:
+    assert not loader.loaded_values
+
+
+def test_fall_through_with_no_boto3(loader: AWSParameterStore) -> None:
+    with patch.object(ssm_loader_module, "boto3", None):
+        assert not loader.load_values(aws_sstore=TEST_PATH, aws_region=TEST_REGION)
+        assert not loader.loaded_values
+
+
+def test_none_client_no_region(loader: AWSParameterStore) -> None:
+    assert loader.get_aws_client() is None

--- a/tests/awsparameterstore_loader_test.py
+++ b/tests/awsparameterstore_loader_test.py
@@ -11,6 +11,7 @@ from secretbox.awsparameterstore_loader import AWSParameterStore
 boto3_lib = pytest.importorskip("boto3", reason="boto3")
 mypy_boto3 = pytest.importorskip("mypy_boto3_ssm", reason="mypy_boto3")
 
+# Isolate boto3 lib requirements, silence flake8 by nesting in if statement
 if True:
     import botocore.client
     import botocore.session

--- a/tests/awssecret_loader_base_test.py
+++ b/tests/awssecret_loader_base_test.py
@@ -1,0 +1,63 @@
+"""Unit tests for aws secrect manager interactions"""
+from typing import Any
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+from secretbox import awssecret_loader as awssecret_loader_module
+from secretbox.awssecret_loader import AWSSecretLoader
+
+TEST_KEY_NAME = "TEST_KEY"
+TEST_VALUE = "abcdefg"
+TEST_STORE = "my_store"
+TEST_STORE_INVALID = "store_not_found"
+TEST_REGION = "us-east-1"
+
+
+@pytest.fixture
+def awssecret_loader() -> Generator[AWSSecretLoader, None, None]:
+    """Create a fixture to test with"""
+    loader = AWSSecretLoader()
+    assert not loader.loaded_values
+    yield loader
+
+
+@pytest.mark.usefixtures("remove_aws_creds")
+def test_load_aws_no_credentials(awssecret_loader: AWSSecretLoader) -> None:
+    """Cause a NoCredentialsError to be handled"""
+    awssecret_loader.load_values(
+        aws_sstore_name=TEST_STORE,
+        aws_region_name=TEST_REGION,
+    )
+    assert not awssecret_loader.loaded_values
+
+
+@pytest.mark.usefixtures("remove_aws_creds")
+def test_load_aws_no_secret_store_defined(awssecret_loader: AWSSecretLoader) -> None:
+    awssecret_loader.load_values(
+        aws_sstore_name=None,
+        aws_region_name=TEST_REGION,
+    )
+    assert not awssecret_loader.loaded_values
+
+
+@pytest.mark.usefixtures("remove_aws_creds")
+def test_get_client_without_region(
+    awssecret_loader: AWSSecretLoader,
+    caplog: Any,
+) -> None:
+    awssecret_loader.aws_region = None
+    result = awssecret_loader.get_aws_client()
+    assert result is None
+    assert "No valid AWS region" in caplog.text
+
+
+def test_boto3_not_installed_auto_load(awssecret_loader: AWSSecretLoader) -> None:
+    """Skip loading AWS secrets manager if no boto3"""
+    with patch.object(awssecret_loader_module, "boto3", None):
+        assert not awssecret_loader.loaded_values
+        awssecret_loader.load_values(
+            aws_sstore_name=TEST_STORE,
+            aws_region_name=TEST_REGION,
+        )
+        assert not awssecret_loader.loaded_values

--- a/tests/awssecret_loader_base_test.py
+++ b/tests/awssecret_loader_base_test.py
@@ -1,4 +1,4 @@
-"""Unit tests for aws secrect manager interactions"""
+"""Unit tests for aws secrect manager interactions without boto3"""
 from typing import Any
 from typing import Generator
 from unittest.mock import patch

--- a/tests/awssecret_loader_test.py
+++ b/tests/awssecret_loader_test.py
@@ -1,4 +1,4 @@
-"""Unit tests for aws secrect manager interactions"""
+"""Unit tests for aws secrect manager interactions with boto3"""
 import json
 from datetime import datetime
 from typing import Any
@@ -12,6 +12,7 @@ from secretbox.awssecret_loader import AWSSecretLoader
 boto3_lib = pytest.importorskip("boto3", reason="boto3")
 mypy_boto3 = pytest.importorskip("mypy_boto3_secretsmanager", reason="mypy_boto3")
 
+# Isolate boto3 lib requirements, silence flake8 by nesting in if statement
 if True:
     import botocore.client
     import botocore.session

--- a/tests/awssecret_loader_test.py
+++ b/tests/awssecret_loader_test.py
@@ -1,19 +1,22 @@
 """Unit tests for aws secrect manager interactions"""
-import importlib
 import json
-import sys
 from datetime import datetime
 from typing import Any
 from typing import Generator
 from unittest.mock import patch
 
-import botocore.client
-import botocore.session
 import pytest
-from botocore.client import BaseClient
-from botocore.stub import Stubber
 from secretbox import awssecret_loader as awssecret_loader_module
 from secretbox.awssecret_loader import AWSSecretLoader
+
+boto3_lib = pytest.importorskip("boto3", reason="boto3")
+mypy_boto3 = pytest.importorskip("mypy_boto3_secretsmanager", reason="mypy_boto3")
+
+if True:
+    import botocore.client
+    import botocore.session
+    from botocore.client import BaseClient
+    from botocore.stub import Stubber
 
 TEST_KEY_NAME = "TEST_KEY"
 TEST_VALUE = "abcdefg"
@@ -75,25 +78,6 @@ def awssecret_loader() -> Generator[AWSSecretLoader, None, None]:
     yield loader
 
 
-@pytest.mark.usefixtures("remove_aws_creds")
-def test_load_aws_no_credentials(awssecret_loader: AWSSecretLoader) -> None:
-    """Cause a NoCredentialsError to be handled"""
-    awssecret_loader.load_values(
-        aws_sstore_name=TEST_STORE,
-        aws_region_name=TEST_REGION,
-    )
-    assert not awssecret_loader.loaded_values
-
-
-@pytest.mark.usefixtures("remove_aws_creds")
-def test_load_aws_no_secret_store_defined(awssecret_loader: AWSSecretLoader) -> None:
-    awssecret_loader.load_values(
-        aws_sstore_name=None,
-        aws_region_name=TEST_REGION,
-    )
-    assert not awssecret_loader.loaded_values
-
-
 def test_load_aws_client_no_region(
     awssecret_loader: AWSSecretLoader,
     caplog: Any,
@@ -104,17 +88,6 @@ def test_load_aws_client_no_region(
             aws_region_name=TEST_REGION,
         )
     assert "Invalid secrets manager client" in caplog.text
-
-
-@pytest.mark.usefixtures("remove_aws_creds")
-def test_get_client_without_region(
-    awssecret_loader: AWSSecretLoader,
-    caplog: Any,
-) -> None:
-    awssecret_loader.aws_region = None
-    result = awssecret_loader.get_aws_client()
-    assert result is None
-    assert "No valid AWS region" in caplog.text
 
 
 def test_load_aws_secrets_valid_store_and_invalid_store(
@@ -140,17 +113,6 @@ def test_load_aws_secrets_valid_store_and_invalid_store(
         assert awssecret_loader.loaded_values.get(TEST_KEY_NAME) is None
 
 
-def test_boto3_not_installed_auto_load(awssecret_loader: AWSSecretLoader) -> None:
-    """Skip loading AWS secrets manager if no boto3"""
-    with patch.object(awssecret_loader_module, "boto3", None):
-        assert not awssecret_loader.loaded_values
-        awssecret_loader.load_values(
-            aws_sstore_name=TEST_STORE,
-            aws_region_name=TEST_REGION,
-        )
-        assert not awssecret_loader.loaded_values
-
-
 def test_boto3_stubs_not_installed(
     awssecret_loader: AWSSecretLoader,
     mockclient: BaseClient,
@@ -164,19 +126,3 @@ def test_boto3_stubs_not_installed(
                 aws_region_name=TEST_REGION,
             )
             assert awssecret_loader.loaded_values
-
-
-def test_boto3_missing_import_catch() -> None:
-    with patch.dict(sys.modules, {"boto3": None}):
-        importlib.reload(awssecret_loader_module)
-        assert awssecret_loader_module.boto3 is None
-    # Reload after test to avoid polution
-    importlib.reload(awssecret_loader_module)
-
-
-def test_boto3_stubs_missing_import_catch() -> None:
-    with patch.dict(sys.modules, {"mypy_boto3_secretsmanager.client": None}):
-        importlib.reload(awssecret_loader_module)
-        assert awssecret_loader_module.SecretsManagerClient is None
-    # Reload after test to avoid polution
-    importlib.reload(awssecret_loader_module)

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,14 @@ envlist = py37,py38,py39,py310,pre-commit
 skip_missing_interpreters = true
 
 [testenv]
-deps = .[aws]
+deps = .
 commands =
     python -m pip install --upgrade pytest coverage
     coverage erase
-    coverage run -m pytest {posargs:tests}
+    coverage run --parallel-mode -m pytest {posargs:tests}
+    python -m pip install .[aws]
+    coverage run --parallel-mode -m pytest {posargs:tests}
+    coverage combine
     coverage xml
     coverage report --fail-under 95 --skip-covered --skip-empty -m
 


### PR DESCRIPTION
closes #63 

Remove the `importlib` calls which simulated `boto3` and `mypy_boto3_...` missing from the installed library. Replace with split tests that are run with a basic install, then with a full optional install `[aws]`.
