### PR TITLE
Prevent Boto3 debug logging

### DIFF
--- a/src/secretbox/aws_loader.py
+++ b/src/secretbox/aws_loader.py
@@ -69,7 +69,7 @@ class AWSLoader(Loader):
             self.logger.error("Unexpected error occurred: '%s'", str(err))
 
     @contextmanager
-    def filter_boto_debug(self) -> Generator[None, None, None]:
+    def disable_debug_logging(self) -> Generator[None, None, None]:
         """Context manager to enforce level 20 (INFO) logging minimum at root logger."""
         restore_data: list[tuple[logging.Logger, int]] = []
 

--- a/src/secretbox/aws_loader.py
+++ b/src/secretbox/aws_loader.py
@@ -74,8 +74,10 @@ class AWSLoader(Loader):
         current_level = self.logger.root.level
         if self.hide_boto_debug and self.logger.root.level < logging.INFO:
             self.logger.root.level = logging.INFO
+            logging.getLogger("boto3").level = logging.INFO
 
         try:
             yield None
         finally:
             self.logger.root.level = current_level
+            logging.getLogger("boto3").level = current_level

--- a/src/secretbox/aws_loader.py
+++ b/src/secretbox/aws_loader.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 import logging
 import os
+from contextlib import contextmanager
 from typing import Any
+from typing import Generator
 
 try:
     from botocore.awsrequest import HeadersDict
@@ -63,6 +65,19 @@ class AWSLoader(Loader):
             )
         else:
             self.logger.error("Unexpected error occurred: '%s'", str(err))
+
+    @contextmanager
+    def filter_boto_debug(self) -> Generator[None, None, None]:
+        """Context manager to enforce level 20 (INFO) logging minimum at root logger."""
+        current_level = self.logger.root.level
+        # TODO: Rename filter_secrets -> boto_debug
+        if self.filter_secrets and self.logger.root.level < logging.INFO:
+            self.logger.root.level = logging.INFO
+
+        try:
+            yield None
+        finally:
+            self.logger.root.level = current_level
 
     @staticmethod
     def secrets_filter(record: logging.LogRecord) -> bool:

--- a/src/secretbox/awsparameterstore_loader.py
+++ b/src/secretbox/awsparameterstore_loader.py
@@ -62,7 +62,7 @@ class AWSParameterStore(AWSLoader):
 
             try:
                 # ensure that boto3 doesn't write sensitive payload to the logger
-                with self.filter_boto_debug():
+                with self.disable_debug_logging():
                     resp = aws_client.get_parameters_by_path(**args)
 
             except ClientError as err:
@@ -95,7 +95,10 @@ class AWSParameterStore(AWSLoader):
             self.logger.debug("Missing AWS region, cannot create client")
             return None
 
-        return boto3.client(
-            service_name="ssm",
-            region_name=self.aws_region,
-        )
+        with self.disable_debug_logging():
+            client = boto3.client(
+                service_name="ssm",
+                region_name=self.aws_region,
+            )
+
+        return client

--- a/src/secretbox/awssecret_loader.py
+++ b/src/secretbox/awssecret_loader.py
@@ -53,7 +53,7 @@ class AWSSecretLoader(AWSLoader):
         secrets: dict[str, str] = {}
         try:
             # ensure that boto3 doesn't write sensitive payload to the logger
-            with self.filter_boto_debug():
+            with self.disable_debug_logging():
                 response = aws_client.get_secret_value(SecretId=self.aws_sstore)
 
         except NoCredentialsError as err:
@@ -76,7 +76,10 @@ class AWSSecretLoader(AWSLoader):
             self.logger.error("No valid AWS region, cannot create client.")
             return None
 
-        return boto3.client(
-            service_name="secretsmanager",
-            region_name=self.aws_region,
-        )
+        with self.disable_debug_logging():
+            client = boto3.client(
+                service_name="secretsmanager",
+                region_name=self.aws_region,
+            )
+
+        return client

--- a/tests/aws_loader_test.py
+++ b/tests/aws_loader_test.py
@@ -53,29 +53,31 @@ def test_populate_region_store_names_kw(awsloader: AWSLoader) -> None:
 def test_filter_boto_debug(caplog: Any, awsloader: AWSLoader) -> None:
     try:
         logger = logging.getLogger("secrets")
+        logger.setLevel("DEBUG")
         current_level = logger.root.level
         logger.root.setLevel("DEBUG")
 
         with awsloader.filter_boto_debug():
-            logger.debug("DEBUG")
-            logger.info("INFO")
+            logger.debug("OHNO")
+            logger.info("ALLGOOD")
 
     finally:
         logger.root.level = current_level
 
-    assert "DEBUG" not in caplog.text
-    assert "INFO" in caplog.text
+    assert "OHNO" not in caplog.text
+    assert "ALLGOOD" in caplog.text
+    assert logger.level == logging.DEBUG
 
 
 def test_filter_boto_debug_no_action(caplog: Any, awsloader: AWSLoader) -> None:
     logger = logging.getLogger("secrets")
 
     with awsloader.filter_boto_debug():
-        logger.debug("DEBUG")
-        logger.error("ERROR")
+        logger.debug("OHNO")
+        logger.error("ALLGOOD")
 
-    assert "DEBUG" not in caplog.text
-    assert "ERROR" in caplog.text
+    assert "OHNO" not in caplog.text
+    assert "ALLGOOD" in caplog.text
 
 
 def test_filter_boto_debug_disabled(caplog: Any, awsloader: AWSLoader) -> None:

--- a/tests/aws_loader_test.py
+++ b/tests/aws_loader_test.py
@@ -54,10 +54,12 @@ def test_filter_boto_debug(caplog: Any, awsloader: AWSLoader) -> None:
     try:
         logger = logging.getLogger("secrets")
         logger.setLevel("DEBUG")
+        error_logger = logging.getLogger("errors")
+        error_logger.setLevel("ERROR")
         current_level = logger.root.level
-        logger.root.setLevel("DEBUG")
+        # logger.root.setLevel("DEBUG")
 
-        with awsloader.filter_boto_debug():
+        with awsloader.disable_debug_logging():
             logger.debug("OHNO")
             logger.info("ALLGOOD")
 
@@ -67,12 +69,13 @@ def test_filter_boto_debug(caplog: Any, awsloader: AWSLoader) -> None:
     assert "OHNO" not in caplog.text
     assert "ALLGOOD" in caplog.text
     assert logger.level == logging.DEBUG
+    assert error_logger.level == logging.ERROR
 
 
 def test_filter_boto_debug_no_action(caplog: Any, awsloader: AWSLoader) -> None:
     logger = logging.getLogger("secrets")
 
-    with awsloader.filter_boto_debug():
+    with awsloader.disable_debug_logging():
         logger.debug("OHNO")
         logger.error("ALLGOOD")
 
@@ -87,7 +90,7 @@ def test_filter_boto_debug_disabled(caplog: Any, awsloader: AWSLoader) -> None:
         logger.root.setLevel("DEBUG")
         awsloader.hide_boto_debug = False
 
-        with awsloader.filter_boto_debug():
+        with awsloader.disable_debug_logging():
             logger.debug("DEBUG")
             logger.info("INFO")
 

--- a/tests/aws_loader_test.py
+++ b/tests/aws_loader_test.py
@@ -50,27 +50,50 @@ def test_populate_region_store_names_kw(awsloader: AWSLoader) -> None:
         assert awsloader.aws_region == "NewRegion"
 
 
-def test_secret_filter(caplog: Any) -> None:
+def test_filter_boto_debug(caplog: Any, awsloader: AWSLoader) -> None:
+    try:
+        logger = logging.getLogger("secrets")
+        current_level = logger.root.level
+        logger.root.setLevel("DEBUG")
+
+        with awsloader.filter_boto_debug():
+            logger.debug("DEBUG")
+            logger.info("INFO")
+
+    finally:
+        logger.root.level = current_level
+
+    assert "DEBUG" not in caplog.text
+    assert "INFO" in caplog.text
+
+
+def test_filter_boto_debug_no_action(caplog: Any, awsloader: AWSLoader) -> None:
     logger = logging.getLogger("secrets")
-    logger.addFilter(AWSLoader.secrets_filter)
-    logger.setLevel("DEBUG")
-    secret_dict = {"allYour": "Passwords"}
-    secret_tuple = ("I am a plain-text secrets",)
-    secret_string = "Your password is 12345"
 
-    logger.debug("Reponse body: %s", secret_dict)
-    logger.debug("Reponse body: %s", secret_tuple)
-    logger.debug("Reponse body: %s", secret_string)
-    logger.debug("Response body:")
-    logger.debug("Standard log")
+    with awsloader.filter_boto_debug():
+        logger.debug("DEBUG")
+        logger.error("ERROR")
 
-    logger.info("Safe Info")
+    assert "DEBUG" not in caplog.text
+    assert "ERROR" in caplog.text
 
-    assert "Passwords" not in caplog.text
-    assert "plain-text" not in caplog.text
-    assert "12345" not in caplog.text
-    assert "Standard log" in caplog.text
-    assert "Safe Info" in caplog.text
+
+def test_filter_boto_debug_disabled(caplog: Any, awsloader: AWSLoader) -> None:
+    try:
+        logger = logging.getLogger("secrets")
+        current_level = logger.root.level
+        logger.root.setLevel("DEBUG")
+        awsloader.hide_boto_debug = False
+
+        with awsloader.filter_boto_debug():
+            logger.debug("DEBUG")
+            logger.info("INFO")
+
+    finally:
+        logger.root.level = current_level
+
+    assert "DEBUG" in caplog.text
+    assert "INFO" in caplog.text
 
 
 def test_log_aws_error_with_nonaws_error(awsloader: AWSLoader, caplog: Any) -> None:


### PR DESCRIPTION
This change prevents any boto3 debug logging by default in secretbox. This is a change from the previous filter which specifically targeted `botocore.parse` and removed sensitive data pulled from secret store or parameter store.  With this change, logging level of `INFO` (20) is enforced when a boto3 call is made.

This can be disabled by flipping the `hide_boto_debug` class variable to `False` for either of the two AWS handlers. Note, this should never be done in production as boto3 modules will log, in plain text, your secrets and the bearer secrets that boto3 is using for AWS requests.

closes #77 