### PR TITLE
Preocts 20220620 add set method

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,13 @@ if __name__ == "__main__":
 
 **NOTE:** All .get methods pull from the instance state of the class and do not reflect changes to the enviornment post-load.
 
-**.get(key: str, default: str | None = None) -> str** -- *deprecated*
+**.get(key: str, default: str | None = None) -> str**
 
 - Returns the string value of the loaded value by key name. If the key does not exists then `KeyError` will be raised unless a default is given, then that is returned.
+
+**.set(key: str, value: str) -> None**
+
+- Adds the key:value pair to both the secretbox instance and the environment variables
 
 **.get_int(key: str, default: int | None = None) -> int** -- *deprecated*
 

--- a/src/secretbox/secretbox.py
+++ b/src/secretbox/secretbox.py
@@ -113,11 +113,16 @@ class SecretBox:
 
     def get(self, key: str, default: str | None = None) -> str:
         """Get a value by key, return default if not found or raise if no default"""
-        self.logger.warning("Deprecated: `.get()` will be removed in v2.7.0")
         if default is None:
             return self._loaded_values[key]
 
         return self._loaded_values.get(key, default)
+
+    def set(self, key: str, value: str) -> None:
+        """Set a value by key. Will be converted to string and pushed to environment."""
+        value = str(value)
+        self._loaded_values[key] = value
+        self._push_to_environment()
 
     def get_int(self, key: str, default: int | None = None) -> int:
         """Convert value by key to int."""

--- a/tests/secretbox_test.py
+++ b/tests/secretbox_test.py
@@ -114,3 +114,17 @@ def test_load_debug_flag(caplog: Any) -> None:
 
     _ = SecretBox(debug_flag=True)
     assert "Debug flag passed." in caplog.text
+
+
+def test_set(secretbox: SecretBox) -> None:
+    """Set a value"""
+    secretbox.set("TEST", "TEST")
+    assert secretbox.get("TEST") == "TEST"
+    assert os.getenv("TEST") == "TEST"
+
+
+def test_set_converts_to_str(secretbox: SecretBox) -> None:
+    """Set a value"""
+    secretbox.set("TEST", 42)  # type: ignore
+    assert secretbox.get("TEST") == "42"
+    assert os.getenv("TEST") == "42"


### PR DESCRIPTION
This change introduces the `.set()` method for `SecretBox`. Allows the injection of secrets to `SecretBox` and the environment at a code level.