### PR TITLE
Simplified surrounding quote removal regex

### DIFF
--- a/src/secretbox/envfile_loader.py
+++ b/src/secretbox/envfile_loader.py
@@ -83,7 +83,7 @@ class EnvFileLoader(Loader):
             value = value.strip()
 
             # Strip surrounding ' or " if both present
-            value = RE_LTQUOTES.match(value).group(2) or value
+            value = self.RE_LTQUOTES.match(value).group(2) or value
 
             self._loaded_values[key] = value
 

--- a/src/secretbox/envfile_loader.py
+++ b/src/secretbox/envfile_loader.py
@@ -83,7 +83,8 @@ class EnvFileLoader(Loader):
             value = value.strip()
 
             # Strip surrounding ' or " if both present
-            value = self.RE_LTQUOTES.match(value).group(2) or value
+            if m := self.RE_LTQUOTES.match(value):
+                value = m.group(2) or value
 
             self._loaded_values[key] = value
 

--- a/src/secretbox/envfile_loader.py
+++ b/src/secretbox/envfile_loader.py
@@ -26,8 +26,7 @@ from secretbox.loader import Loader
 class EnvFileLoader(Loader):
     """Load local .env file"""
 
-    LT_DBL_QUOTES = r'^".*"$'
-    LT_SGL_QUOTES = r"^'.*'$"
+    RE_LTQUOTES = re.compile(r"([\"'])(.*)\1$|^(.*)$")
     EXPORT_PREFIX = r"^\s*?export\s"
 
     logger = logging.getLogger(__name__)
@@ -82,21 +81,11 @@ class EnvFileLoader(Loader):
 
             key = self.strip_export(key).strip()
             value = value.strip()
-
-            if value.startswith('"'):
-                value = self.remove_lt_dbl_quotes(value)
-            elif value.startswith("'"):
-                value = self.remove_lt_sgl_quotes(value)
+            
+            # Strip surrounding ' or " if both present
+            value = RE_LTQUOTES.match(value).group(2) or value
 
             self._loaded_values[key] = value
-
-    def remove_lt_dbl_quotes(self, in_: str) -> str:
-        """Removes matched leading and trailing double quotes"""
-        return in_.strip('"') if re.match(self.LT_DBL_QUOTES, in_) else in_
-
-    def remove_lt_sgl_quotes(self, in_: str) -> str:
-        """Removes matched leading and trailing double quotes"""
-        return in_.strip("'") if re.match(self.LT_SGL_QUOTES, in_) else in_
 
     def strip_export(self, in_: str) -> str:
         """Removes leading 'export ' prefix, case agnostic"""

--- a/src/secretbox/envfile_loader.py
+++ b/src/secretbox/envfile_loader.py
@@ -82,11 +82,14 @@ class EnvFileLoader(Loader):
             key = self.strip_export(key).strip()
             value = value.strip()
 
-            # Strip surrounding ' or " if both present
-            if m := self.RE_LTQUOTES.match(value):
-                value = m.group(2) or value
+            value = self.remove_lt_quotes(value)
 
             self._loaded_values[key] = value
+
+    def remove_lt_quotes(self, in_: str) -> str:
+        """Removes matched leading and trailing single / double quotes"""
+        m = self.RE_LTQUOTES.match(in_)
+        return m.group(2) if m and m.group(2) else in_
 
     def strip_export(self, in_: str) -> str:
         """Removes leading 'export ' prefix, case agnostic"""

--- a/src/secretbox/envfile_loader.py
+++ b/src/secretbox/envfile_loader.py
@@ -81,7 +81,7 @@ class EnvFileLoader(Loader):
 
             key = self.strip_export(key).strip()
             value = value.strip()
-            
+
             # Strip surrounding ' or " if both present
             value = RE_LTQUOTES.match(value).group(2) or value
 


### PR DESCRIPTION
## Simplified regex usage for surrounding quote removal 

This proposal simplified the existing 2 function calls and conditional statements by using a single compiled regex argument. It should improve performance and simplify future usage.

### The following regex is used:
```regex
([\"'])(.*)\1$|^(.*)$
```
> This matches for surrounding single or double quotes, but only if at the beginning and end of the text, and only if both types match. This is logically equivalent to the original implementation.

### Runnable Test Example:
```py
import re

# These will all resolve to "Text isn't there."
test_1 = [
	"Text isn't there.",
	"\"Text isn't there.\"",
	"'Text isn't there.'",
]

# These cases will not be changed,
# since the quote types does not match.
test_2 = [
    "'Text isn't there.",
    "Text isn't there.'",
    "\"Text isn't there.'",
    "Text isn't there.'\"",
]

RE_LTQUOTES = re.compile(r"([\"'])(.*)\1$|^(.*)$")

def remove_lt_quotes(in_: str) -> str:
    """Removes matched leading and trailing single / double quotes"""
    m = RE_LTQUOTES.match(in_)
    return m.group(2) if m and m.group(2) else in_

for value in test_1:
    result = remove_lt_quotes(value)
    assert result == "Text isn't there."

for value in test_2:
    result = remove_lt_quotes(value)
    assert result == value
```
	