### PR TITLE
Clean up secretbox class, mypy improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,6 @@ repos:
     rev: v0.961
     hooks:
       - id: mypy
+        args:
+          - "--no-warn-unused-ignores"
+          - "--ignore-missing-imports"

--- a/README.md
+++ b/README.md
@@ -80,9 +80,6 @@ specific `.env` file if it exists. Secrets are loaded in the order of loaders,
 replacing any matching keys from the prior loader.
 
 ```python
-from secretbox import AWSSecretLoader
-from secretbox import EnvFileLoader
-from secretbox import EnvironLoader
 from secretbox import SecretBox
 
 secrets = SecretBox()
@@ -91,9 +88,9 @@ secrets = SecretBox()
 def main() -> int:
     """Main function"""
     secrets.use_loaders(
-        EnvironLoader(),
-        AWSSecretLoader("mySecrets", "us-east-1"),
-        EnvFileLoader("sandbox/.override_env"),
+        secrets.EnvironLoader(),
+        secrets.AWSSecretLoader("mySecrets", "us-east-1"),
+        secrets.EnvFileLoader("sandbox/.override_env"),
     )
 
     my_sevice_password = secrets.values.get("SERVICE_PW")

--- a/README.md
+++ b/README.md
@@ -129,8 +129,6 @@ if __name__ == "__main__":
 
 ---
 
-
-
 ### SecretBox arguments:
 
 `SecretBox(*, auto_load: bool = False, load_debug: bool = False)`
@@ -170,43 +168,6 @@ reflect changes to the enviornment post-load.
 
 - Adds the key:value pair to both the secretbox instance and the environment
   variables
-
-**.get_int(key: str, default: int | None = None) -> int** -- *deprecated*
-
-- Returns the int value of the loaded value by key name. Raise `ValueError` if
-  the found key cannot convert to `int`. Raise `KeyError` if the key is not
-  found and no default is given.
-
-**.get_list(key: str, delimiter: str = ",", default: list[str] | None = None) ->
-List[str]:** -- *deprecated*
-
-- Returns a list of the loaded value by key name, seperated at defined
-  delimiter. No check is made if delimiter exists in value. `default` is
-  returned if key is not found otherwise a `KeyError` is raised.
-
-**.load_from(loaders: list[str], \*\*kwargs: Any) -> None** -- *deprecated*
-
-- Runs load_values from each of the listed loadered in the order they appear
-- Loader options:
-  - **environ**
-    - Loads the current environmental variables into secretbox.
-  - **envfile**
-    - Loads .env file. Optional `filename` kwarg can override the default load
-      of the current working directory `.env` file.
-  - **awssecret**
-    - Loads secrets from an AWS secret manager. Requires `aws_sstore_name` and
-      `aws_region_name` keywords to be provided or for those values to be in the
-      environment variables under `AWS_SSTORE_NAME` and `AWS_REGION_NAME`.
-      `aws_sstore_name` is the name of the store, not the arn.
-  - **awsparameterstore**
-    - Loads secrets from an AWS Parameter Store (SSM/ASM). Requires
-      `aws_sstore_name` and `aws_region_name` keywords to be provided or for
-      those values to be in the environment variables under `AWS_SSTORE_NAME`
-      and `AWS_REGION_NAME`. `aws_sstore_name` is the name or prefix of the
-      parameters to retrieve.
-- **kwargs**
-  - All keyword arguments are passed into the loaders when they are called. Each
-    loader details which extra keyword arguments it uses or requires above.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ documentation = "https://github.com/Preocts/secretbox/README.md"
 repository = "https://github.com/Preocts/secretbox"
 # changelog = ""
 
+[tool.setuptools.package-data]
+"secretbox" = ["py.typed"]
+
 [tool.setuptools.packages.find]
 where = ["src"]  # ["."] by default
 include = ["*"]  # ["*"] by default

--- a/src/secretbox/py.typed
+++ b/src/secretbox/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The mypy package uses inline types.

--- a/src/secretbox/secretbox.py
+++ b/src/secretbox/secretbox.py
@@ -132,29 +132,3 @@ class SecretBox:
         value = str(value)
         self._loaded_values[key] = value
         self._push_to_environment()
-
-    def get_int(self, key: str, default: int | None = None) -> int:
-        """Convert value by key to int."""
-        self._logger.warning("Deprecated: `.get_int()` will be removed in v2.7.0")
-        if default is None:
-            return int(self.get(key))
-
-        value = self.get(key, "")
-        return int(value) if value else default
-
-    def get_list(
-        self,
-        key: str,
-        delimiter: str = ",",
-        default: list[str] | None = None,
-    ) -> list[str]:
-        """Convert value by key to list seperated by delimiter."""
-        self._logger.warning("Deprecated: `.get_list()` will be removed in v2.7.0")
-        if default is None:
-            default = []
-
-        if not default:
-            return self.get(key).split(delimiter)
-
-        value = self.get(key, "")
-        return value.split(delimiter) if value else default

--- a/src/secretbox/secretbox.py
+++ b/src/secretbox/secretbox.py
@@ -27,7 +27,7 @@ LOADERS: dict[str, type[Loader]] = {
 class SecretBox:
     """Loads various environment variables/secrets for use"""
 
-    logger = logging.getLogger(__name__)
+    _logger = logging.getLogger(__name__)
 
     def __init__(
         self,
@@ -42,8 +42,8 @@ class SecretBox:
             auto_load : If true, environment vars and `.env` file will be loaded
             load_debug : When true, internal logger level is set to DEBUG
         """
-        self.logger.setLevel(level="DEBUG" if debug_flag else "ERROR")
-        self.logger.debug("Debug flag passed.")
+        self._logger.setLevel(level="DEBUG" if debug_flag else "ERROR")
+        self._logger.debug("Debug flag passed.")
 
         self._loaded_values: dict[str, str] = {}
 
@@ -90,16 +90,16 @@ class SecretBox:
                 to be in the environment variables under `AWS_SSTORE_NAME` and
                 `AWS_REGION_NAME`. `aws_sstore_name` is not the arn.
         """
-        self.logger.warning("Deprecated: `.load_from()` will be removed in v2.7.0")
+        self._logger.warning("Deprecated: `.load_from()` will be removed in v2.7.0")
         for loader_name in loaders:
-            self.logger.debug("Loading from interface: `%s`", loader_name)
+            self._logger.debug("Loading from interface: `%s`", loader_name)
             interface = LOADERS.get(loader_name)
             if interface is None:
-                self.logger.error("Loader `%s` unknown, skipping", loader_name)
+                self._logger.error("Loader `%s` unknown, skipping", loader_name)
                 continue
             loader = interface()
             loader._load_values(**kwargs)
-            self.logger.debug("Loaded %d values.", len(loader.values))
+            self._logger.debug("Loaded %d values.", len(loader.values))
             self._update_loaded_values(loader.values)
         self._push_to_environment()
 
@@ -110,7 +110,7 @@ class SecretBox:
     def _push_to_environment(self) -> None:
         """Pushes loaded values to local environment vars, will overwrite existing"""
         for key, value in self._loaded_values.items():
-            self.logger.debug("Push, %s : ***%s", key, value[-(len(value) // 4) :])
+            self._logger.debug("Push, %s : ***%s", key, value[-(len(value) // 4) :])
             os.environ[key] = value
 
     def get(self, key: str, default: str | None = None) -> str:
@@ -128,7 +128,7 @@ class SecretBox:
 
     def get_int(self, key: str, default: int | None = None) -> int:
         """Convert value by key to int."""
-        self.logger.warning("Deprecated: `.get_int()` will be removed in v2.7.0")
+        self._logger.warning("Deprecated: `.get_int()` will be removed in v2.7.0")
         if default is None:
             return int(self.get(key))
 
@@ -142,7 +142,7 @@ class SecretBox:
         default: list[str] | None = None,
     ) -> list[str]:
         """Convert value by key to list seperated by delimiter."""
-        self.logger.warning("Deprecated: `.get_list()` will be removed in v2.7.0")
+        self._logger.warning("Deprecated: `.get_list()` will be removed in v2.7.0")
         if default is None:
             default = []
 

--- a/src/secretbox/secretbox.py
+++ b/src/secretbox/secretbox.py
@@ -10,17 +10,20 @@ import logging
 import os
 from typing import Any
 
-from secretbox.awsparameterstore_loader import AWSParameterStoreLoader
-from secretbox.awssecret_loader import AWSSecretLoader
-from secretbox.envfile_loader import EnvFileLoader
-from secretbox.environ_loader import EnvironLoader
+from secretbox.awsparameterstore_loader import (
+    AWSParameterStoreLoader as _AWSParameterStoreLoader,
+)
+from secretbox.awssecret_loader import AWSSecretLoader as _AWSSecretLoader
+from secretbox.envfile_loader import EnvFileLoader as _EnvFileLoader
+from secretbox.environ_loader import EnvironLoader as _EnvironLoader
 from secretbox.loader import Loader
 
+# To be removed with 2.8.0
 LOADERS: dict[str, type[Loader]] = {
-    "envfile": EnvFileLoader,
-    "environ": EnvironLoader,
-    "awssecret": AWSSecretLoader,
-    "awsparameterstore": AWSParameterStoreLoader,
+    "envfile": _EnvFileLoader,
+    "environ": _EnvironLoader,
+    "awssecret": _AWSSecretLoader,
+    "awsparameterstore": _AWSParameterStoreLoader,
 }
 
 
@@ -28,6 +31,10 @@ class SecretBox:
     """Loads various environment variables/secrets for use"""
 
     _logger = logging.getLogger(__name__)
+    AWSParameterStoreLoader = _AWSParameterStoreLoader
+    AWSSecretLoader = _AWSSecretLoader
+    EnvFileLoader = _EnvFileLoader
+    EnvironLoader = _EnvironLoader
 
     def __init__(
         self,
@@ -48,7 +55,7 @@ class SecretBox:
         self._loaded_values: dict[str, str] = {}
 
         if auto_load:
-            self.use_loaders(EnvironLoader(), EnvFileLoader())
+            self.use_loaders(self.EnvironLoader(), self.EnvFileLoader())
 
     @property
     def values(self) -> dict[str, str]:
@@ -90,7 +97,7 @@ class SecretBox:
                 to be in the environment variables under `AWS_SSTORE_NAME` and
                 `AWS_REGION_NAME`. `aws_sstore_name` is not the arn.
         """
-        self._logger.warning("Deprecated: `.load_from()` will be removed in v2.7.0")
+        self._logger.warning("Deprecated: `.load_from()` will be removed in v2.8.0")
         for loader_name in loaders:
             self._logger.debug("Loading from interface: `%s`", loader_name)
             interface = LOADERS.get(loader_name)

--- a/tests/secretbox_test.py
+++ b/tests/secretbox_test.py
@@ -73,41 +73,6 @@ def test_get_default_missing_key(secretbox: SecretBox) -> None:
     assert secretbox.get("BYWHATCHANCEWOULDTHISSEXIST", "Hello") == "Hello"
 
 
-def test_get_as_valid_int(secretbox: SecretBox) -> None:
-    """Helper to return ints"""
-    with patch.dict(os.environ, {"TEST_INT": "42"}):
-        secretbox.load_from(["environ"])
-        assert secretbox.get_int("TEST_INT") == 42
-        assert secretbox.get_int("TEST_INT", 0) == 42
-
-
-def test_get_as_invalid_int(secretbox: SecretBox) -> None:
-    """Helper to return ints should raise on assumption that value is an int"""
-    with patch.dict(os.environ, {"TEST_INT": "Forty-two"}):
-        secretbox.load_from(["environ"])
-        with pytest.raises(ValueError):
-            secretbox.get_int("TEST_INT", -1)
-
-
-def test_get_default_int(secretbox: SecretBox) -> None:
-    """Return the default if provided instead of raising"""
-    assert secretbox.get_int("NOTTHERE", 10) == 10
-
-
-def test_get_as_list(secretbox: SecretBox) -> None:
-    """Helper to return a list based on given delimiter"""
-    with patch.dict(os.environ, {"TEST_STR": "rooBlank", "TEST_LIST": "1 | 2|3"}):
-        secretbox.load_from(["environ"])
-        assert secretbox.get_list("TEST_LIST") == ["1 | 2|3"]
-        assert secretbox.get_list("TEST_STR", "|") == ["rooBlank"]
-        assert secretbox.get_list("TEST_LIST", "|") == ["1 ", " 2", "3"]
-
-
-def test_get_as_list_default(secretbox: SecretBox) -> None:
-    """Return the default if provided instead of raising"""
-    assert secretbox.get_list("NOTTHERE", ",", ["1", "2", "3"]) == ["1", "2", "3"]
-
-
 def test_load_debug_flag(caplog: Any) -> None:
     """Ensure logging is silentish"""
     _ = SecretBox()


### PR DESCRIPTION
This change pulls references to the available loaders into the `SecretBox` class for qol.

- Removed `get_int()`, `get_list()`

Also add the `py.typed` file to the module.