### PR TITLE
Preocts 20220727

### DIFF
--- a/src/secretbox/aws_loader.py
+++ b/src/secretbox/aws_loader.py
@@ -84,16 +84,13 @@ class AWSLoader(Loader):
     @contextmanager
     def disable_debug_logging(self) -> Generator[None, None, None]:
         """Context manager to enforce level 20 (INFO) logging minimum at root logger."""
-        restore_data: list[tuple[logging.Logger, int]] = []
+        # This should prevent boto and botocore loggers from outputting
+        # client secrets in plaintext if debug logging is on.
+        prior_root_level = logging.getLogger().level
 
-        # Step through all loggers, force INFO level or higher
         if self.hide_boto_debug:
             self.logger.info("Forcing all loggers to > DEBUG level.")
-            for log_obj in logging.root.manager.loggerDict:
-                logger = logging.getLogger(log_obj)
-                if logger.level < logging.INFO:
-                    restore_data.append((logger, logger.level))
-                    logger.level = logging.INFO
+            logging.getLogger().setLevel(logging.INFO)
 
         try:
             yield None
@@ -101,5 +98,4 @@ class AWSLoader(Loader):
         finally:
             if self.hide_boto_debug:
                 self.logger.info("Restoring previous loggers settings.")
-            for logger, level in restore_data:
-                logger.level = level
+                logging.getLogger().setLevel(prior_root_level)

--- a/src/secretbox/awsparameterstore_loader.py
+++ b/src/secretbox/awsparameterstore_loader.py
@@ -105,31 +105,31 @@ class AWSParameterStoreLoader(AWSLoader):
             "WithDecryption": True,
         }
 
-        # loop through next page tokens, page size caps at 10
-        while True:
+        # ensure that boto3 doesn't write sensitive payload to the logger
+        with self.disable_debug_logging():
+            # loop through next page tokens, page size caps at 10
+            while True:
 
-            try:
-                # ensure that boto3 doesn't write sensitive payload to the logger
-                with self.disable_debug_logging():
+                try:
                     resp = aws_client.get_parameters_by_path(**args)
 
-            except ClientError as err:
-                self.log_aws_error(err)
-                return False
+                except ClientError as err:
+                    self.log_aws_error(err)
+                    return False
 
-            # Process results, break if finished
-            for param in resp["Parameters"] or []:
-                # remove the prefix
-                # we want /path/to/DB_PASSWORD to populate os.env.DB_PASSWORD
-                key = param["Name"].split("/")[-1] if do_split else param["Name"]
-                self._loaded_values[key] = param["Value"]
+                # Process results, break if finished
+                for param in resp["Parameters"] or []:
+                    # remove the prefix
+                    # we want /path/to/DB_PASSWORD to populate os.env.DB_PASSWORD
+                    key = param["Name"].split("/")[-1] if do_split else param["Name"]
+                    self._loaded_values[key] = param["Value"]
 
-            args["NextToken"] = resp.get("NextToken")
+                args["NextToken"] = resp.get("NextToken")
 
-            if not args["NextToken"]:
-                break
+                if not args["NextToken"]:
+                    break
 
-            self.logger.debug("fetching next page: %s", args["NextToken"])
+                self.logger.debug("fetching next page: %s", args["NextToken"])
 
         self.logger.info(
             "loaded %d parameters matching %s",

--- a/tests/aws_loader_test.py
+++ b/tests/aws_loader_test.py
@@ -52,25 +52,25 @@ def test_populate_region_store_names_kw(awsloader: AWSLoader) -> None:
 
 
 def test_filter_boto_debug(caplog: Any, awsloader: AWSLoader) -> None:
+    prior_root_level = logging.getLogger().level
+    logging.getLogger().setLevel("DEBUG")
+
     try:
         logger = logging.getLogger("secrets")
-        logger.setLevel("DEBUG")
-        error_logger = logging.getLogger("errors")
-        error_logger.setLevel("ERROR")
-        current_level = logger.root.level
-        # logger.root.setLevel("DEBUG")
 
+        logging.getLogger().debug("Baseline Start")
         with awsloader.disable_debug_logging():
             logger.debug("OHNO")
             logger.info("ALLGOOD")
+        logging.getLogger().debug("Baseline End")
 
     finally:
-        logger.root.level = current_level
+        logging.getLogger().setLevel(prior_root_level)
 
+    assert "Baseline Start" in caplog.text
+    assert "Baseline End" in caplog.text
     assert "OHNO" not in caplog.text
     assert "ALLGOOD" in caplog.text
-    assert logger.level == logging.DEBUG
-    assert error_logger.level == logging.ERROR
 
 
 def test_filter_boto_debug_no_action(caplog: Any, awsloader: AWSLoader) -> None:


### PR DESCRIPTION
Cleaner, easier way to suppress the output of `boto3` and `botocore` libraries that will dump your AWS auth token and plain-text parameter secrets to the logs.

closes #92 

