### PR TITLE
Refactor AWS loaders for handling exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ adjacent libraries that reference `os.environ` values by default. Required
 values can be kept in a `.env` file instead of managing a script to load them
 into the environment.
 
+**Note**: The default behavior of `secretbox` is to hide exceptions during
+loading. This places the detection of missing values on the caller. This
+behavior can be altered by passing `capture_exceptions=False` to any loader.
+Exceptions will be raised from their source as `LoaderException`.
+
 ---
 
 ### Requirements
@@ -85,6 +90,7 @@ This loads the system environment variables, an AWS secret store, and then a
 specific `.env` file if it exists. Secrets are loaded in the order of loaders,
 replacing any matching keys from the prior loader.
 
+
 ```python
 from secretbox import SecretBox
 
@@ -149,6 +155,9 @@ if __name__ == "__main__":
 - When true, internal logger level is set to DEBUG. Secret values are truncated,
   however it is not recommended to leave this on for production deployments.
 
+
+  *note:* Does not enable debug output for aws loaders.
+
 ### SecretBox API:
 
 **.values**
@@ -204,6 +213,17 @@ Load secrets from an AWS secret manager.
   - aws_region: [str] Regional location of secret store
     - Can be provided through environ `AWS_REGION_NAME` or `AWS_REGION`
 
+- Keyword Args:
+  - hide_boto_debug: [bool, default = `True`]
+    - Hides debug logging output from botocore clients to prevent exposing
+      plain-text secrets
+  - capture_exceptions: [bool, default = `True`]
+    - All internal exceptions are captured, logged, and ignored.
+
+- Raises:
+  - `LoaderException` if `capture_exceptions` is `False`. All exceptions are
+    raised from their source.
+
 **AWSParameterStoreLoader**
 
 Load secrets from AWS parameter store.
@@ -214,6 +234,17 @@ Load secrets from AWS parameter store.
     - Can be provided through environ `AWS_SSTORE_NAME`
   - aws_region: [str] Regional Location of parameter(s)
     - Can be provided through environ `AWS_REGION_NAME` or `AWS_REGION`
+
+- Keyword Args:
+  - hide_boto_debug: [bool, default = `True`]
+    - Hides debug logging output from botocore clients to prevent exposing
+      plain-text secrets
+  - capture_exceptions: [bool, default = `True`]
+    - All internal exceptions are captured, logged, and ignored.
+
+- Raises:
+  - `LoaderException` if `capture_exceptions` is `False`. All exceptions are
+    raised from their source.
 
 ---
 

--- a/src/secretbox/aws_loader.py
+++ b/src/secretbox/aws_loader.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     HeadersDict = dict  # type: ignore
 
+from secretbox.exceptions import LoaderException
 from secretbox.loader import Loader
 
 
@@ -61,7 +62,28 @@ class AWSLoader(Loader):
         raise NotImplementedError()
 
     def run(self) -> bool:
-        """To be overrided in child classes"""
+        """
+        Load secrets from AWS. Returns success.
+
+        Raises:
+            secretbox.exceptions.LoaderException
+
+            NOTE: Only raises if `capture_exceptions` is False
+        """
+        try:
+            return self._run()
+
+        # We use a blanket Exception catch here on purpose.
+        except Exception as err:
+            self.log_aws_error(err)
+            if not self._capture_exceptions:
+                raise LoaderException(err) from err
+
+        return False
+
+    def _run(self) -> bool:
+        """Internal run called from self.run()."""
+        # NOTE: To be implemented in child classes.
         raise NotImplementedError()
 
     def get_aws_client(self) -> Any:

--- a/src/secretbox/aws_loader.py
+++ b/src/secretbox/aws_loader.py
@@ -25,9 +25,31 @@ class AWSLoader(Loader):
 
     logger = logging.getLogger(__name__)
 
-    # Override hide_boto_debug to False to allow full debug logging of boto3 libraries
-    # NOTE: This exposes sensitive data and should never be in production
-    hide_boto_debug = True
+    def __init__(
+        self,
+        aws_sstore_name: str | None = None,
+        aws_region_name: str | None = None,
+        *,
+        hide_boto_debug: bool = True,
+        capture_exceptions: bool = True,
+    ) -> None:
+        """
+        Load secrets from AWS parameter store.
+
+        Args:
+            aws_sstore: Name of parameter or path of parameters if endings with `/`
+                Can be provided through environ `AWS_SSTORE_NAME`
+            aws_region: Regional Location of parameter(s)
+                Can be provided through environ `AWS_REGION_NAME` or `AWS_REGION`
+            hide_boto_debug: Hides debug output while using boto libraries
+            capture_exceptions: All inner exceptions are captured, logged, and ignored
+        """
+        self.aws_sstore = aws_sstore_name
+        self.aws_region = aws_region_name
+
+        self._loaded_values: dict[str, str] = {}
+        self._hide_boto_debug = hide_boto_debug
+        self._capture_exceptions = capture_exceptions
 
     def _load_values(self, **kwargs: Any) -> bool:
         """To be overrided in child classes"""
@@ -88,7 +110,7 @@ class AWSLoader(Loader):
         # client secrets in plaintext if debug logging is on.
         prior_root_level = logging.getLogger().level
 
-        if self.hide_boto_debug:
+        if self._hide_boto_debug:
             self.logger.info("Forcing all loggers to > DEBUG level.")
             logging.getLogger().setLevel(logging.INFO)
 
@@ -96,6 +118,6 @@ class AWSLoader(Loader):
             yield None
 
         finally:
-            if self.hide_boto_debug:
+            if self._hide_boto_debug:
                 self.logger.info("Restoring previous loggers settings.")
                 logging.getLogger().setLevel(prior_root_level)

--- a/src/secretbox/awsparameterstore_loader.py
+++ b/src/secretbox/awsparameterstore_loader.py
@@ -31,7 +31,7 @@ class AWSParameterStoreLoader(AWSLoader):
         """Copy of loaded values"""
         return self._loaded_values.copy()
 
-    def run(self) -> bool:
+    def _run(self) -> bool:
         """Load secrets from given AWS parameter store."""
         has_loaded = self._load_values()
 

--- a/src/secretbox/awsparameterstore_loader.py
+++ b/src/secretbox/awsparameterstore_loader.py
@@ -26,25 +26,6 @@ except ImportError:
 class AWSParameterStoreLoader(AWSLoader):
     """Load secrets from an AWS Parameter Store"""
 
-    def __init__(
-        self,
-        aws_sstore_name: str | None = None,
-        aws_region_name: str | None = None,
-    ) -> None:
-        """
-        Load secrets from AWS parameter store.
-
-        Args:
-            aws_sstore: Name of parameter or path of parameters if endings with `/`
-                Can be provided through environ `AWS_SSTORE_NAME`
-            aws_region: Regional Location of parameter(s)
-                Can be provided through environ `AWS_REGION_NAME` or `AWS_REGION`
-        """
-        self.aws_sstore = aws_sstore_name
-        self.aws_region = aws_region_name
-
-        self._loaded_values: dict[str, str] = {}
-
     @property
     def values(self) -> dict[str, str]:
         """Copy of loaded values"""

--- a/src/secretbox/awsparameterstore_loader.py
+++ b/src/secretbox/awsparameterstore_loader.py
@@ -11,9 +11,6 @@ from secretbox.aws_loader import AWSLoader
 
 try:
     import boto3
-    from botocore.exceptions import ClientError
-    from botocore.exceptions import NoCredentialsError
-    from botocore.exceptions import PartialCredentialsError
 except ImportError:
     boto3 = None  # type: ignore
 
@@ -93,12 +90,7 @@ class AWSParameterStoreLoader(AWSLoader):
             # loop through next page tokens, page size caps at 10
             while True:
 
-                try:
-                    resp = aws_client.get_parameters_by_path(**args)
-
-                except (NoCredentialsError, ClientError) as err:
-                    self.log_aws_error(err)
-                    return False
+                resp = aws_client.get_parameters_by_path(**args)
 
                 # Process results, break if finished
                 for param in resp["Parameters"] or []:
@@ -129,13 +121,9 @@ class AWSParameterStoreLoader(AWSLoader):
             return None
 
         with self.disable_debug_logging():
-            try:
-                client = boto3.client(
-                    service_name="ssm",
-                    region_name=self.aws_region,
-                )
-            except PartialCredentialsError as err:
-                self.log_aws_error(err)
-                return None
+            client = boto3.client(
+                service_name="ssm",
+                region_name=self.aws_region,
+            )
 
         return client

--- a/src/secretbox/awssecret_loader.py
+++ b/src/secretbox/awssecret_loader.py
@@ -33,7 +33,7 @@ class AWSSecretLoader(AWSLoader):
         """Copy of loaded values"""
         return self._loaded_values.copy()
 
-    def run(self) -> bool:
+    def _run(self) -> bool:
         """Load all secrets from given AWS secret store."""
         has_loaded = self._load_values()
 

--- a/src/secretbox/awssecret_loader.py
+++ b/src/secretbox/awssecret_loader.py
@@ -26,24 +26,7 @@ from secretbox.aws_loader import AWSLoader
 
 
 class AWSSecretLoader(AWSLoader):
-    def __init__(
-        self,
-        aws_sstore_name: str | None = None,
-        aws_region_name: str | None = None,
-    ) -> None:
-        """
-        Load secrets from an AWS secret manager.
-
-        Args:
-            aws_sstore: Name of the secret store (not the arn)
-                Can be provided through environ `AWS_SSTORE_NAME`
-            aws_region: Regional location of secret store
-                Can be provided through environ `AWS_REGION_NAME` or `AWS_REGION`
-        """
-        self.aws_sstore = aws_sstore_name
-        self.aws_region = aws_region_name
-
-        self._loaded_values: dict[str, str] = {}
+    """Load secrets from an AWS Secret Store"""
 
     @property
     def values(self) -> dict[str, str]:

--- a/src/secretbox/exceptions.py
+++ b/src/secretbox/exceptions.py
@@ -1,0 +1,9 @@
+"""Custom Exceptions."""
+from __future__ import annotations
+
+
+class LoaderException(Exception):
+    """Custom Exception for all loader exceptions."""
+
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)

--- a/tests/aws_loader_test.py
+++ b/tests/aws_loader_test.py
@@ -89,7 +89,7 @@ def test_filter_boto_debug_disabled(caplog: Any, awsloader: AWSLoader) -> None:
         logger = logging.getLogger("debug_disabled")
         current_level = logger.root.level
         logger.root.setLevel("DEBUG")
-        awsloader.hide_boto_debug = False
+        awsloader._hide_boto_debug = False
 
         with awsloader.disable_debug_logging():
             logger.debug("DEBUG")

--- a/tests/awsparameterstore_loader_test.py
+++ b/tests/awsparameterstore_loader_test.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from botocore.exceptions import ClientError
 from secretbox.awsparameterstore_loader import AWSParameterStoreLoader
 
 boto3_lib = pytest.importorskip("boto3", reason="boto3")
@@ -216,11 +217,12 @@ def test_missing_region(loader: AWSParameterStoreLoader, caplog: Any) -> None:
     assert "Invalid SSM client" in caplog.text
 
 
-def test_client_error_catch_on_load(broken_loader: AWSParameterStoreLoader) -> None:
-    assert not broken_loader._load_values(
-        aws_sstore_name=TEST_PATH,
-        aws_region_name=TEST_REGION,
-    )
+def test_client_error_thrown_on_load(broken_loader: AWSParameterStoreLoader) -> None:
+    with pytest.raises(ClientError):
+        assert not broken_loader._load_values(
+            aws_sstore_name=TEST_PATH,
+            aws_region_name=TEST_REGION,
+        )
 
 
 def test_client_with_region(loader: AWSParameterStoreLoader) -> None:

--- a/tests/awsparameterstore_loader_test.py
+++ b/tests/awsparameterstore_loader_test.py
@@ -1,14 +1,13 @@
 """Unit tests for aws parameter store interactions with boto3"""
 from __future__ import annotations
 
-import os
 from collections.abc import Generator
 from typing import Any
 from unittest.mock import patch
 
 import pytest
-from botocore.exceptions import ClientError
 from secretbox.awsparameterstore_loader import AWSParameterStoreLoader
+from secretbox.exceptions import LoaderException
 
 boto3_lib = pytest.importorskip("boto3", reason="boto3")
 mypy_boto3 = pytest.importorskip("mypy_boto3_ssm", reason="mypy_boto3")
@@ -18,6 +17,7 @@ if True:
     import botocore.client
     import botocore.session
     from botocore.client import BaseClient
+    from botocore.exceptions import ClientError
     from botocore.exceptions import StubAssertionError
     from botocore.stub import Stubber
 
@@ -230,15 +230,26 @@ def test_client_with_region(loader: AWSParameterStoreLoader) -> None:
     assert loader.get_aws_client() is not None
 
 
-def test_partial_credentials() -> None:
-    with patch.dict(os.environ, {}):
-        os.environ.pop("AWS_SECRET_ACCESS_KEY")
-        loader = AWSParameterStoreLoader("/some/path", "us-east-1")
+@pytest.mark.usefixtures("remove_aws_creds")
+def test_invalid_credentials_raises_exception() -> None:
+    loader = AWSParameterStoreLoader(
+        aws_sstore_name="/some/path",
+        aws_region_name="us-east-1",
+        capture_exceptions=False,
+    )
+
+    with pytest.raises(LoaderException):
         loader.run()
 
 
 @pytest.mark.usefixtures("remove_aws_creds")
-def test_invalid_credentials() -> None:
-    # TODO: Block discovery of aws cred files
-    loader = AWSParameterStoreLoader("/some/path", "us-east-1")
-    loader.run()
+def test_invalid_credentials_does_not_raise_exception() -> None:
+    loader = AWSParameterStoreLoader(
+        aws_sstore_name="/some/path",
+        aws_region_name="us-east-1",
+        capture_exceptions=True,
+    )
+
+    result = loader.run()
+
+    assert result is False

--- a/tests/awssecret_loader_base_test.py
+++ b/tests/awssecret_loader_base_test.py
@@ -6,7 +6,6 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-from botocore.exceptions import NoCredentialsError
 from secretbox import awssecret_loader as awssecret_loader_module
 from secretbox.awssecret_loader import AWSSecretLoader
 
@@ -23,17 +22,6 @@ def awssecret_loader() -> Generator[AWSSecretLoader, None, None]:
     loader = AWSSecretLoader()
     assert not loader._loaded_values
     yield loader
-
-
-@pytest.mark.usefixtures("remove_aws_creds")
-def test_load_aws_no_credentials(awssecret_loader: AWSSecretLoader) -> None:
-    """Cause a NoCredentialsError to be handled"""
-    with pytest.raises(NoCredentialsError):
-        awssecret_loader._load_values(
-            aws_sstore_name=TEST_STORE,
-            aws_region_name=TEST_REGION,
-        )
-    assert not awssecret_loader._loaded_values
 
 
 @pytest.mark.usefixtures("remove_aws_creds")

--- a/tests/awssecret_loader_base_test.py
+++ b/tests/awssecret_loader_base_test.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from botocore.exceptions import NoCredentialsError
 from secretbox import awssecret_loader as awssecret_loader_module
 from secretbox.awssecret_loader import AWSSecretLoader
 
@@ -27,10 +28,11 @@ def awssecret_loader() -> Generator[AWSSecretLoader, None, None]:
 @pytest.mark.usefixtures("remove_aws_creds")
 def test_load_aws_no_credentials(awssecret_loader: AWSSecretLoader) -> None:
     """Cause a NoCredentialsError to be handled"""
-    awssecret_loader._load_values(
-        aws_sstore_name=TEST_STORE,
-        aws_region_name=TEST_REGION,
-    )
+    with pytest.raises(NoCredentialsError):
+        awssecret_loader._load_values(
+            aws_sstore_name=TEST_STORE,
+            aws_region_name=TEST_REGION,
+        )
     assert not awssecret_loader._loaded_values
 
 

--- a/tests/awssecret_loader_test.py
+++ b/tests/awssecret_loader_test.py
@@ -9,6 +9,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from botocore.exceptions import ClientError
 from secretbox import awssecret_loader as awssecret_loader_module
 from secretbox.awssecret_loader import AWSSecretLoader
 
@@ -128,10 +129,11 @@ def test_load_aws_secrets_valid_store_and_invalid_store(
 
         # Reset and test invalid response
         awssecret_loader._loaded_values = {}
-        awssecret_loader._load_values(
-            aws_sstore_name=TEST_STORE_INVALID,
-            aws_region_name=TEST_REGION,
-        )
+        with pytest.raises(ClientError):
+            awssecret_loader._load_values(
+                aws_sstore_name=TEST_STORE_INVALID,
+                aws_region_name=TEST_REGION,
+            )
         assert awssecret_loader.values.get(TEST_KEY_NAME) is None
 
 


### PR DESCRIPTION
This change reduces the number of branches that need to be tested by
removing the try/catch branches from the loads. Instead a single
try/catch is used at the `run()` method and the exceptions are either
squashed or bubble up, depending on an argument of the loader.

The default behavior of `secretbox` is maintained: Exceptions are squashed
by default.