### PR TITLE
Correct tests after refactors

### DIFF
--- a/tests/aws_loader_test.py
+++ b/tests/aws_loader_test.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pytest
 from secretbox.aws_loader import AWSLoader
+from secretbox.exceptions import LoaderException
 
 
 @pytest.fixture
@@ -16,6 +17,26 @@ def awsloader() -> Generator[AWSLoader, None, None]:
     """Create a fixture to test with"""
     loader = AWSLoader()
     yield loader
+
+
+def test_run_raises_with_flag(awsloader: AWSLoader) -> None:
+    awsloader._capture_exceptions = False
+    with patch.object(awsloader, "_run", side_effect=Exception) as run:
+
+        with pytest.raises(LoaderException):
+            awsloader.run()
+
+    assert run.call_count == 1
+
+
+def test_run_does_not_rause_with_flag(awsloader: AWSLoader) -> None:
+    awsloader._capture_exceptions = True
+    with patch.object(awsloader, "_run", side_effect=Exception) as run:
+
+        result = awsloader.run()
+
+    assert run.call_count == 1
+    assert result is False
 
 
 def test_populate_region_store_names_none(awsloader: AWSLoader) -> None:

--- a/tests/aws_loader_test.py
+++ b/tests/aws_loader_test.py
@@ -129,3 +129,19 @@ def test_log_aws_error_with_nonaws_error(awsloader: AWSLoader, caplog: Any) -> N
     except Exception as err:
         awsloader.log_aws_error(err)
     assert "Manufactored exception" in caplog.text
+
+
+def test_log_aws_error_with_aws_error(awsloader: AWSLoader, caplog: Any) -> None:
+    try:
+        raise Exception("Manufactored exception")
+    except Exception as err:
+        setattr(
+            err,
+            "response",
+            {
+                "Error": {"Code": "313", "Message": "AWS error"},
+                "ResponseMetadata": "Beepbeep",
+            },
+        )
+        awsloader.log_aws_error(err)
+    assert "313 - AWS error (Beepbeep)" in caplog.text

--- a/tests/awsparameterstore_loader_test.py
+++ b/tests/awsparameterstore_loader_test.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 import pytest
 from secretbox.awsparameterstore_loader import AWSParameterStoreLoader
-from secretbox.exceptions import LoaderException
 
 boto3_lib = pytest.importorskip("boto3", reason="boto3")
 mypy_boto3 = pytest.importorskip("mypy_boto3_ssm", reason="mypy_boto3")
@@ -228,28 +227,3 @@ def test_client_error_thrown_on_load(broken_loader: AWSParameterStoreLoader) -> 
 def test_client_with_region(loader: AWSParameterStoreLoader) -> None:
     loader.aws_region = TEST_REGION
     assert loader.get_aws_client() is not None
-
-
-@pytest.mark.usefixtures("remove_aws_creds")
-def test_invalid_credentials_raises_exception() -> None:
-    loader = AWSParameterStoreLoader(
-        aws_sstore_name="/some/path",
-        aws_region_name="us-east-1",
-        capture_exceptions=False,
-    )
-
-    with pytest.raises(LoaderException):
-        loader.run()
-
-
-@pytest.mark.usefixtures("remove_aws_creds")
-def test_invalid_credentials_does_not_raise_exception() -> None:
-    loader = AWSParameterStoreLoader(
-        aws_sstore_name="/some/path",
-        aws_region_name="us-east-1",
-        capture_exceptions=True,
-    )
-
-    result = loader.run()
-
-    assert result is False

--- a/tests/awssecret_loader_test.py
+++ b/tests/awssecret_loader_test.py
@@ -10,7 +10,6 @@ from unittest.mock import patch
 import pytest
 from secretbox import awssecret_loader as awssecret_loader_module
 from secretbox.awssecret_loader import AWSSecretLoader
-from secretbox.exceptions import LoaderException
 
 boto3_lib = pytest.importorskip("boto3", reason="boto3")
 mypy_boto3 = pytest.importorskip("mypy_boto3_secretsmanager", reason="mypy_boto3")
@@ -177,20 +176,3 @@ def test_boto3_stubs_not_installed(
                 aws_region_name=TEST_REGION,
             )
             assert awssecret_loader.values
-
-
-@pytest.mark.usefixtures("remove_aws_creds")
-def test_invalid_credentials_raises_exception() -> None:
-    loader = AWSSecretLoader("somestore", "us-east-1", capture_exceptions=False)
-
-    with pytest.raises(LoaderException):
-        loader.run()
-
-
-@pytest.mark.usefixtures("remove_aws_creds")
-def test_invalid_credentials_does_not_raise_exception() -> None:
-    loader = AWSSecretLoader("somestore", "us-east-1", capture_exceptions=True)
-
-    result = loader.run()
-
-    assert result is False


### PR DESCRIPTION
This change moves two tests into the `aws_loader` to test the `run` method directly instead of testing it indirectly via the separate modules.  We also completely test `log_aws_error` method now that the loaders are not catching exceptions themselves.