### PR TITLE
pre-commit updates with formatting changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,45 +14,28 @@ repos:
       - id: check-docstring-first
       - id: debug-statements
       - id: mixed-line-ending
-        args:
-          - "--fix=lf"
 
-  # Adds a standard feel to import segments, adds future annotations
-  - repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.12.0
+  # Adds a standard feel to import segments
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
     hooks:
-      - id: reorder-python-imports
+      - id: isort
         args:
-          - "--py37-plus"
+          - "--force-single-line-imports"
           - "--add-import"
           - "from __future__ import annotations"
-          - "--application-directories"
-          - ".:src"
-
-  # Automatically upgrade syntax to newer versions
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args:
-          - "--py38-plus"
+          - "--profile"
+          - "black"
 
   # Format code. No, I don't like everything black does either.
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.1.1
     hooks:
       - id: black
 
-  # Format docs.
-  - repo: https://github.com/asottile/blacken-docs
-    rev: 1.16.0
-    hooks:
-      - id: blacken-docs
-        additional_dependencies: [black>=23.3.0]
-
   # Flake8 for linting, line-length adjusted to match Black default
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         additional_dependencies:

--- a/src/secretbox/aws_loader.py
+++ b/src/secretbox/aws_loader.py
@@ -4,6 +4,7 @@ Super class for AWS secrets manager and parameter store loaders
 Author  : Preocts <preocts#8196>
 Git Repo: https://github.com/Preocts/secretbox
 """
+
 from __future__ import annotations
 
 import logging

--- a/src/secretbox/awsparameterstore_loader.py
+++ b/src/secretbox/awsparameterstore_loader.py
@@ -3,10 +3,11 @@ Author      : James McKain (@jjmckain)
 Created     : 2021-12-10
 SCM Repo    : https://github.com/Preocts/secretbox
 """
+
 from __future__ import annotations
 
-from typing import Any
 from typing import TYPE_CHECKING
+from typing import Any
 
 from secretbox.aws_loader import AWSLoader
 

--- a/src/secretbox/awssecret_loader.py
+++ b/src/secretbox/awssecret_loader.py
@@ -4,11 +4,12 @@ Load secrets from an AWS secret manager
 Author  : Preocts <Preocts#8196>
 Git Repo: https://github.com/Preocts/secretbox
 """
+
 from __future__ import annotations
 
 import json
-from typing import Any
 from typing import TYPE_CHECKING
+from typing import Any
 
 try:
     import boto3

--- a/src/secretbox/envfile_loader.py
+++ b/src/secretbox/envfile_loader.py
@@ -14,6 +14,7 @@ I'm open to suggestions on standards to follow here.
 Author  : Preocts <Preocts#8196>
 Git Repo: https://github.com/Preocts/secretbox
 """
+
 from __future__ import annotations
 
 import logging

--- a/src/secretbox/environ_loader.py
+++ b/src/secretbox/environ_loader.py
@@ -4,6 +4,7 @@ Load system environ values
 Author  : Preocts <Preocts#8196>
 Git Repo: https://github.com/Preocts/secretbox
 """
+
 from __future__ import annotations
 
 import logging

--- a/src/secretbox/exceptions.py
+++ b/src/secretbox/exceptions.py
@@ -1,4 +1,5 @@
 """Custom Exceptions."""
+
 from __future__ import annotations
 
 

--- a/src/secretbox/secretbox.py
+++ b/src/secretbox/secretbox.py
@@ -4,6 +4,7 @@ Loads various environment variables/secrets for use
 Author  : Preocts <Preocts#8196>
 Git Repo: https://github.com/Preocts/secretbox
 """
+
 from __future__ import annotations
 
 import logging

--- a/tests/aws_loader_test.py
+++ b/tests/aws_loader_test.py
@@ -1,4 +1,5 @@
 """Unit tests for aws loader"""
+
 from __future__ import annotations
 
 import logging

--- a/tests/awsparameterstore_loader_base_test.py
+++ b/tests/awsparameterstore_loader_base_test.py
@@ -1,4 +1,5 @@
 """Unit tests for aws parameter store interactions without boto3"""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/awsparameterstore_loader_test.py
+++ b/tests/awsparameterstore_loader_test.py
@@ -1,4 +1,5 @@
 """Unit tests for aws parameter store interactions with boto3"""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/awssecret_loader_base_test.py
+++ b/tests/awssecret_loader_base_test.py
@@ -1,4 +1,5 @@
 """Unit tests for aws secrect manager interactions without boto3"""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/awssecret_loader_test.py
+++ b/tests/awssecret_loader_test.py
@@ -1,4 +1,5 @@
 """Unit tests for aws secrect manager interactions with boto3"""
+
 from __future__ import annotations
 
 import json

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Global fixtures and statics"""
+
 from __future__ import annotations
 
 import os
@@ -7,7 +8,6 @@ from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
-
 
 AWS_ENV_KEYS = [
     "AWS_ACCESS_KEY",

--- a/tests/envfile_loader_test.py
+++ b/tests/envfile_loader_test.py
@@ -1,4 +1,5 @@
 """Unit tests for .env file loader"""
+
 # import os
 from __future__ import annotations
 

--- a/tests/environ_loader_test.py
+++ b/tests/environ_loader_test.py
@@ -1,4 +1,5 @@
 """Simple test to ensure we read environ"""
+
 from __future__ import annotations
 
 import os

--- a/tests/secretbox_test.py
+++ b/tests/secretbox_test.py
@@ -1,4 +1,5 @@
 """Unit tests against secretbox.py"""
+
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
black 24.1 formatting changes

Do to conflicts against the format of `black`, the tool `reorder-python-imports` is replaced with `isort`.

Removing `pyupgrade` to reduce tool opinionation further.