### PR TITLE
Strip down secretbox.py for 3.0

### DIFF
--- a/src/secretbox/secretbox.py
+++ b/src/secretbox/secretbox.py
@@ -1,139 +1,69 @@
-"""
-Loads various environment variables/secrets for use
-
-Author  : Preocts <Preocts#8196>
-Git Repo: https://github.com/Preocts/secretbox
-"""
-
 from __future__ import annotations
 
 import logging
 import os
-from typing import Any
-
-from secretbox.awsparameterstore_loader import (
-    AWSParameterStoreLoader as _AWSParameterStoreLoader,
-)
-from secretbox.awssecret_loader import AWSSecretLoader as _AWSSecretLoader
-from secretbox.envfile_loader import EnvFileLoader as _EnvFileLoader
-from secretbox.environ_loader import EnvironLoader as _EnvironLoader
-from secretbox.loader import Loader
-
-# To be removed with 2.8.0
-LOADERS: dict[str, type[Loader]] = {
-    "envfile": _EnvFileLoader,
-    "environ": _EnvironLoader,
-    "awssecret": _AWSSecretLoader,
-    "awsparameterstore": _AWSParameterStoreLoader,
-}
 
 
 class SecretBox:
-    """Loads various environment variables/secrets for use"""
+    """
+    A key-value store optionally loaded from the local environment and other sources.
 
-    _logger = logging.getLogger(__name__)
-    AWSParameterStoreLoader = _AWSParameterStoreLoader
-    AWSSecretLoader = _AWSSecretLoader
-    EnvFileLoader = _EnvFileLoader
-    EnvironLoader = _EnvironLoader
+    All keys will be normalized to upper-case. Key lookups are case-sensitive.
+    """
 
-    def __init__(
-        self,
-        *,
-        auto_load: bool = False,
-        debug_flag: bool = False,
-    ) -> None:
+    logger = logging.getLogger(__name__)
+
+    def __init__(self, *, load_environ: bool = False) -> None:
         """
         Initialize SecretBox
 
         Keyword Args:
-            auto_load : If true, environment vars and `.env` file will be loaded
-            load_debug : When true, internal logger level is set to DEBUG
+            load_environ : Load existing environment variables when True.
         """
-        self._logger.setLevel(level="DEBUG" if debug_flag else "ERROR")
-        self._logger.debug("Debug flag passed.")
-
         self._loaded_values: dict[str, str] = {}
 
-        if auto_load:
-            self.use_loaders(self.EnvironLoader(), self.EnvFileLoader())
+        if load_environ:
+            self._loaded_values = {
+                key.upper(): value for key, value in os.environ.items()
+            }
 
     @property
-    def values(self) -> dict[str, str]:
-        """Property: loaded values."""
+    def loaded_values(self) -> dict[str, str]:
         return self._loaded_values.copy()
 
-    def use_loaders(self, *loaders: Loader) -> None:
+    def __getitem__(self, key: str) -> str:
         """
-        Loaded results are injected into environ and stored in state.
+        Get a loaded value by key.
 
         Args:
-            loaders: Variable length argument list of Loaders to execute.
+            key: Key to lookup for requested value
+
+        Returns:
+            str
+
+        Raises:
+            KeyError
         """
-        for loader in loaders:
-            loader.run()
-            self._loaded_values.update(loader.values)
+        return self._loaded_values[key]
 
-        self._push_to_environment()
-
-    def load_from(
-        self,
-        loaders: list[str],
-        **kwargs: Any,
-    ) -> None:
+    def __setitem__(self, key: str, value: str) -> None:
         """
-        Runs load_values from each of the listed loader in the order they appear
+        Set a value assigned to a key. The key and value must be a string.
 
-        Deprecated: This method will be replaced with `.use_loaders()` in v2.7.0
+        NOTE: Keys will be normalized to upper-case.
 
-        Loader options:
-            environ:
-                Loads the current environmental variables into secretbox.
-            envfile:
-                Loads .env file. Optional `filename` kwarg can override the default
-                load of the current working directory `.env` file.
-            awssecret:
-                Loads secrets from an AWS secret manager. Requires `aws_sstore_name`
-                and `aws_region_name` keywords to be provided or for those values
-                to be in the environment variables under `AWS_SSTORE_NAME` and
-                `AWS_REGION_NAME`. `aws_sstore_name` is not the arn.
+        Args:
+            key: Key index of the value
+            value: Value stored at the provided key index
+
+        Returns:
+            None
+
+        Raises:
+            ValueError: If the key or value are not a string
         """
-        self._logger.warning("Deprecated: `.load_from()` will be removed in v2.8.0")
-        for loader_name in loaders:
-            self._logger.debug("Loading from interface: `%s`", loader_name)
-            interface = LOADERS.get(loader_name)
-            if interface is None:
-                self._logger.error("Loader `%s` unknown, skipping", loader_name)
-                continue
-            loader = interface()
-            loader._load_values(**kwargs)
-            self._logger.debug("Loaded %d values.", len(loader.values))
-            self._update_loaded_values(loader.values)
-        self._push_to_environment()
+        if not isinstance(key, str) or not isinstance(value, str):
+            msg = f"Keys and values of a Secretbox object must be of type str. You provided: {type(key).__name__}:{type(value).__name__}"
+            raise TypeError(msg)
 
-    def _update_loaded_values(self, new_values: dict[str, str]) -> None:
-        """Update/Create instance state of loaded values with new values"""
-        self._loaded_values.update(new_values)
-
-    def _push_to_environment(self) -> None:
-        """Pushes loaded values to local environment vars, will overwrite existing"""
-        for key, value in self._loaded_values.items():
-            self._logger.debug("Push, %s : ***%s", key, value[-(len(value) // 4) :])
-            os.environ[key] = value
-
-    def get(self, key: str, default: str | None = None) -> str:
-        """Get a value by key, return default if not found or raise if no default"""
-        if default is None:
-            return self._loaded_values[key]
-
-        return self._loaded_values.get(key, default)
-
-    def set(self, key: str, value: str) -> None:  # noqa: A003
-        """Set a value by key. Will be converted to string and pushed to environment."""
-        value = str(value)
-        self._loaded_values[key] = value
-        self._push_to_environment()
-
-    def is_set(self, key: str) -> bool:
-        """Returns true if key is set in the loaded values."""
-        return key in self._loaded_values
+        self._loaded_values[key.upper()] = value


### PR DESCRIPTION
A complete rewrite of the library from the ground up. The prior
mentality of design was for secretbox to be silent and swallow errors
over raising during run-time. It was expected that missing values or
failures would, eventually, cause an error.

The new approach will focus on a fail-fast approach.

SecretBox objects will hold a `dict[str, str]`. Optionally this
can be pre-loaded with the existing environment variables from
`os.environ`.

The SecretBox object should behave, within reason, as a dictionary. Due
to opinion, all keys in the SecretBox store will be normilized to
uppercase.

Support for `__getitem__` and `__setitem__` added.