### PR TITLE
Remove auto-load of environment variables

### DIFF
--- a/src/secretbox/secretbox.py
+++ b/src/secretbox/secretbox.py
@@ -1,31 +1,12 @@
 from __future__ import annotations
 
-import logging
-import os
-
 
 class SecretBox:
-    """
-    A key-value store optionally loaded from the local environment and other sources.
+    """A key-value store optionally loaded from the local environment and other sources."""
 
-    All keys will be normalized to upper-case. Key lookups are case-sensitive.
-    """
-
-    logger = logging.getLogger(__name__)
-
-    def __init__(self, *, load_environ: bool = False) -> None:
-        """
-        Initialize SecretBox
-
-        Keyword Args:
-            load_environ : Load existing environment variables when True.
-        """
+    def __init__(self) -> None:
+        """Create an empty SecretBox."""
         self._loaded_values: dict[str, str] = {}
-
-        if load_environ:
-            self._loaded_values = {
-                key.upper(): value for key, value in os.environ.items()
-            }
 
     @property
     def loaded_values(self) -> dict[str, str]:
@@ -50,8 +31,6 @@ class SecretBox:
         """
         Set a value assigned to a key. The key and value must be a string.
 
-        NOTE: Keys will be normalized to upper-case.
-
         Args:
             key: Key index of the value
             value: Value stored at the provided key index
@@ -66,4 +45,4 @@ class SecretBox:
             msg = f"Keys and values of a Secretbox object must be of type str. You provided: {type(key).__name__}:{type(value).__name__}"
             raise TypeError(msg)
 
-        self._loaded_values[key.upper()] = value
+        self._loaded_values[key] = value

--- a/tests/secretbox_test.py
+++ b/tests/secretbox_test.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import os
-from unittest.mock import patch
-
 import pytest
 
 from secretbox import SecretBox
@@ -15,8 +12,10 @@ def simple_box() -> SecretBox:
         "foo": "bar",
         "biz": "baz",
     }
-    with patch.dict(os.environ, simple_values, clear=True):
-        sb = SecretBox(load_environ=True)
+    sb = SecretBox()
+
+    for key, value in simple_values.items():
+        sb[key] = value
 
     return sb
 
@@ -31,19 +30,6 @@ def test_loaded_value_property_is_copy(simple_box: SecretBox) -> None:
     assert first_values != second_values
 
 
-def test_init_loads_environment_variables() -> None:
-    # Test that we load the existing environment variables and nothing
-    # else at the time of initialization.
-
-    expected_values = {"FOO": "bar"}
-
-    with patch.dict(os.environ, expected_values, clear=True):
-        sb = SecretBox(load_environ=True)
-    loaded_values = sb.loaded_values
-
-    assert loaded_values == expected_values
-
-
 def test_init_is_empty_when_created() -> None:
     # Creating a SecretBox instance should yield an empty box
     sb = SecretBox()
@@ -55,7 +41,7 @@ def test_init_is_empty_when_created() -> None:
 
 def test_get_item_returns_expected(simple_box: SecretBox) -> None:
     # SecretBox should behave like a dictionary when needed
-    expected_key = "FOO"
+    expected_key = "foo"
     expected_value = "bar"
 
     value = simple_box[expected_key]
@@ -65,7 +51,7 @@ def test_get_item_returns_expected(simple_box: SecretBox) -> None:
 
 def test_get_item_is_case_sensitive(simple_box: SecretBox) -> None:
     # Always raise a KeyError if the key is not found
-    invalid_key = "foo"
+    invalid_key = "FOO"
 
     with pytest.raises(KeyError):
         simple_box[invalid_key]
@@ -78,14 +64,14 @@ def test_set_item_accepts_valid_values(simple_box: SecretBox) -> None:
 
     simple_box["foo"] = expected_value
 
-    updated_value = simple_box["FOO"]
+    updated_value = simple_box["foo"]
     assert updated_value == expected_value
 
 
 def test_set_item_raises_with_invalid_value(simple_box: SecretBox) -> None:
     # SecretBox should only accept strings as values
     with pytest.raises(TypeError):
-        simple_box["foo"] = 1  # type: ignore
+        simple_box["FOO"] = 1  # type: ignore
 
 
 def test_set_item_raises_with_invalid_key(simple_box: SecretBox) -> None:


### PR DESCRIPTION
After consideration of #160, the loading of environment variables should be handled exclusively in a loader. This is kicking the can on how to handle `os.environ` behavior when in a Windows OS. However, it makes sense that the SecretBox instance should be case sensitive with keys. It is patterned to behave like a dictionary. Changing the behavior of `__setitem__` and `__getitem__` here would be more surprising to a dev than not.