### PR TITLE
Implement the .get() method

### DIFF
--- a/src/secretbox/secretbox.py
+++ b/src/secretbox/secretbox.py
@@ -46,3 +46,31 @@ class SecretBox:
             raise TypeError(msg)
 
         self._loaded_values[key] = value
+
+    def get(self, key: str, default: str | None = None) -> str:
+        """
+        Get a value from the SecretBox. If default is provided and the value is not found, return the default instead.
+
+        Args:
+            key: Key index to lookup
+            default: A default return value. If provided, must be a string
+
+        Raises:
+            ValueError: If default is provided but not as a string
+            KeyError: If the key is not present and the default value is None
+        """
+        if default is not None and not isinstance(default, str):
+            msg = f"Default value must be provided as a str. Given {type(default).__name__} instead."
+            raise ValueError(msg)
+
+        try:
+            value = self._loaded_values[key]
+
+        except KeyError as err:
+            if default is not None:
+                value = default
+
+            else:
+                raise err
+
+        return value

--- a/tests/secretbox_test.py
+++ b/tests/secretbox_test.py
@@ -78,3 +78,35 @@ def test_set_item_raises_with_invalid_key(simple_box: SecretBox) -> None:
     # SecretBox should only accept strings as keys
     with pytest.raises(TypeError):
         simple_box[1] = "flapjack"  # type: ignore
+
+
+def test_get_returns_expected_value(simple_box: SecretBox) -> None:
+    # .get("foo") should work the same as ["foo"] when the key exists
+    expected_value = "bar"
+
+    value = simple_box.get("foo")
+
+    assert value == expected_value
+
+
+def test_get_returns_default_when_key_not_exists(simple_box: SecretBox) -> None:
+    # Like .get() on dictionaries, return the default if provided when the key
+    # doens't exist
+    expected_value = "flapjack"
+
+    value = simple_box.get("cardinal", expected_value)
+
+    assert value == expected_value
+
+
+def test_get_raises_keyerror_when_key_not_exists(simple_box: SecretBox) -> None:
+    # Unlike dictionaries, if the default value is not provided None will not
+    # be returned. Secretbox enforces a string return value.
+    with pytest.raises(KeyError):
+        simple_box.get("cardinal")
+
+
+def test_get_raises_valueerror_default_is_not_string(simple_box: SecretBox) -> None:
+    # Type guarding the default value to ensure .get() always returns a string
+    with pytest.raises(ValueError):
+        simple_box.get("answer", 42)  # type: ignore


### PR DESCRIPTION
This method behaves close to the dictionary .get() method with two exceptions. The `default` value, if provided, must be a string. If the `default` value is omitted and the `key` does not exist then a `KeyError` will be raised.