### PR TITLE
Implement .get_int() method

### DIFF
--- a/src/secretbox/secretbox.py
+++ b/src/secretbox/secretbox.py
@@ -74,3 +74,42 @@ class SecretBox:
                 raise err
 
         return value
+
+    def get_int(self, key: str, default: int | None = None) -> int:
+        """
+        Get a value from SecretBox, converting it to an int.
+
+        If default is provided and the value is not found, return the default instead.
+
+        Args:
+            key: Key index to lookup
+            default: A default return value. If provided, must be an int
+
+        Raises:
+            ValueError: If the discovered value cannot be converted to an int
+            TypeError: If default is provided but is not an int
+            KeyError: If the key is not present and the default value is None
+        """
+        if default is not None and not isinstance(default, int):
+            msg = f"Default value must be provided as a int. Given {type(default).__name__} instead."
+            raise TypeError(msg)
+
+        try:
+            # TODO
+            # There is the question of what to do with floats here. If the value is a
+            # float it will successfully be converted to an int. However, that changes
+            # the value. We should likely raise an exception in this case.
+            value = int(self._loaded_values[key])
+
+        except KeyError as err:
+            if default is not None:
+                value = default
+
+            else:
+                raise err
+
+        except ValueError as err:
+            msg = f"The value paired with key '{key}` could not be converted to an int."
+            raise ValueError(msg) from err
+
+        return value

--- a/tests/secretbox_test.py
+++ b/tests/secretbox_test.py
@@ -11,6 +11,7 @@ def simple_box() -> SecretBox:
     simple_values = {
         "foo": "bar",
         "biz": "baz",
+        "answer": "42",
     }
     sb = SecretBox()
 
@@ -110,3 +111,41 @@ def test_get_raises_valueerror_default_is_not_string(simple_box: SecretBox) -> N
     # Type guarding the default value to ensure .get() always returns a string
     with pytest.raises(ValueError):
         simple_box.get("answer", 42)  # type: ignore
+
+
+def test_get_int_returns_expected_value(simple_box: SecretBox) -> None:
+    # .get_int() translates a value to an int
+    expected_value = 42
+
+    value = simple_box.get_int("answer")
+
+    assert value == expected_value
+
+
+def test_get_int_returns_default_when_key_not_exists(simple_box: SecretBox) -> None:
+    # Like .get() on dictionaries, return the default if provided when the key
+    # doens't exist
+    expected_value = 69
+
+    value = simple_box.get_int("nice", expected_value)
+
+    assert value == expected_value
+
+
+def test_get_int_raises_keyerror_when_key_not_exists(simple_box: SecretBox) -> None:
+    # Unlike dictionaries, if the default value is not provided None will not
+    # be returned. Secretbox enforces a string return value.
+    with pytest.raises(KeyError):
+        simple_box.get_int("cardinal")
+
+
+def test_get_int_raises_typeerror_default_is_not_int(simple_box: SecretBox) -> None:
+    # Type guarding the default value to ensure .get() always returns a string
+    with pytest.raises(TypeError):
+        simple_box.get_int("answer", "42")  # type: ignore
+
+
+def test_get_int_raises_valueerror_on_convert_error(simple_box: SecretBox) -> None:
+    # If the value cannot be converted to an int, raise ValueError
+    with pytest.raises(ValueError):
+        simple_box.get_int("foo")


### PR DESCRIPTION
This method attempts to return the requested value as an integer instead of a string. Exceptions are raised if the convertion fails. All other behavior mirrors `.get()`.

There is the question of what to do with floats here. If the value is a float it will successfully be converted to an int. However, that changes the value. We should likely raise an exception in this case.