### PR TITLE
Raise TypeError instead of ValueError

### DIFF
--- a/src/secretbox/secretbox.py
+++ b/src/secretbox/secretbox.py
@@ -49,19 +49,21 @@ class SecretBox:
 
     def get(self, key: str, default: str | None = None) -> str:
         """
-        Get a value from the SecretBox. If default is provided and the value is not found, return the default instead.
+        Get a value from the SecretBox.
+
+        If default is provided and the value is not found, return the default instead.
 
         Args:
             key: Key index to lookup
             default: A default return value. If provided, must be a string
 
         Raises:
-            ValueError: If default is provided but not as a string
+            TypeError: If default is provided but not as a string
             KeyError: If the key is not present and the default value is None
         """
         if default is not None and not isinstance(default, str):
             msg = f"Default value must be provided as a str. Given {type(default).__name__} instead."
-            raise ValueError(msg)
+            raise TypeError(msg)
 
         try:
             value = self._loaded_values[key]

--- a/tests/secretbox_test.py
+++ b/tests/secretbox_test.py
@@ -107,9 +107,9 @@ def test_get_raises_keyerror_when_key_not_exists(simple_box: SecretBox) -> None:
         simple_box.get("cardinal")
 
 
-def test_get_raises_valueerror_default_is_not_string(simple_box: SecretBox) -> None:
+def test_get_raises_typeerror_default_is_not_string(simple_box: SecretBox) -> None:
     # Type guarding the default value to ensure .get() always returns a string
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         simple_box.get("answer", 42)  # type: ignore
 
 


### PR DESCRIPTION
If the `default` arguement is not the correct type, raise a TypeError.