### PR TITLE
Address TODO

### DIFF
--- a/src/secretbox/secretbox.py
+++ b/src/secretbox/secretbox.py
@@ -92,10 +92,6 @@ class SecretBox:
         self._validate_type(default, int, "default")
 
         try:
-            # TODO
-            # There is the question of what to do with floats here. If the value is a
-            # float it will successfully be converted to an int. However, that changes
-            # the value. We should likely raise an exception in this case.
             value = int(self._loaded_values[key])
 
         except KeyError as err:
@@ -106,7 +102,7 @@ class SecretBox:
                 raise err
 
         except ValueError as err:
-            msg = f"The value paired with key '{key}` could not be converted to an int."
+            msg = f"The value of '{key}` could not be converted to an int."
             raise ValueError(msg) from err
 
         return value

--- a/tests/secretbox_test.py
+++ b/tests/secretbox_test.py
@@ -12,6 +12,7 @@ def simple_box() -> SecretBox:
         "foo": "bar",
         "biz": "baz",
         "answer": "42",
+        "funny_number": "69.420",
     }
     sb = SecretBox()
 
@@ -149,3 +150,9 @@ def test_get_int_raises_valueerror_on_convert_error(simple_box: SecretBox) -> No
     # If the value cannot be converted to an int, raise ValueError
     with pytest.raises(ValueError):
         simple_box.get_int("foo")
+
+
+def test_get_int_fails_when_value_is_float(simple_box: SecretBox) -> None:
+    # We do not want type coercion to happen
+    with pytest.raises(ValueError):
+        simple_box.get_int("funny_number")


### PR DESCRIPTION
This is a non-issue for `get_int()`. A string representing a float will raise a ValueError with `int()`.