### PR TITLE
Implement .get_float()

### DIFF
--- a/src/secretbox/secretbox.py
+++ b/src/secretbox/secretbox.py
@@ -107,6 +107,49 @@ class SecretBox:
 
         return value
 
+    def get_float(self, key: str, default: float | None = None) -> float:
+        """
+        Get a value from SecretBox, converting it to an float.
+
+        If default is provided and the value is not found, return the default instead.
+
+        Args:
+            key: Key index to lookup
+            default: A default return value. If provided, must be a float
+
+        Raises:
+            ValueError: If the discovered value is not a float
+            TypeError: If default is provided but is not a float
+            KeyError: If the key is not present and the default value is None
+        """
+        self._validate_type(default, float, "default")
+
+        try:
+            str_value = self._loaded_values[key]
+
+            try:
+                int(str_value)
+            except ValueError:
+                pass
+            else:
+                msg = f"The value of '{key}' is an int."
+                raise ValueError()
+
+            value = float(str_value)
+
+        except KeyError as err:
+            if default is not None:
+                value = default
+
+            else:
+                raise err
+
+        except ValueError as err:
+            msg = f"The value of '{key}` is not a float."
+            raise ValueError(msg) from err
+
+        return value
+
     @staticmethod
     def _validate_type(obj: object | None, _type: type, label: str) -> None:
         """

--- a/tests/secretbox_test.py
+++ b/tests/secretbox_test.py
@@ -156,3 +156,47 @@ def test_get_int_fails_when_value_is_float(simple_box: SecretBox) -> None:
     # We do not want type coercion to happen
     with pytest.raises(ValueError):
         simple_box.get_int("funny_number")
+
+
+def test_get_float_returns_expected_value(simple_box: SecretBox) -> None:
+    # .get_float() translates a value to an float
+    expected_value = 69.420
+
+    value = simple_box.get_float("funny_number")
+
+    assert value == expected_value
+
+
+def test_get_float_returns_default_when_key_not_exists(simple_box: SecretBox) -> None:
+    # Like .get() on dictionaries, return the default if provided when the key
+    # doens't exist
+    expected_value = 867.5309
+
+    value = simple_box.get_float("nice", expected_value)
+
+    assert value == expected_value
+
+
+def test_get_float_raises_keyerror_when_key_not_exists(simple_box: SecretBox) -> None:
+    # Unlike dictionaries, if the default value is not provided None will not
+    # be returned. Secretbox enforces a string return value.
+    with pytest.raises(KeyError):
+        simple_box.get_float("cardinal")
+
+
+def test_get_float_raises_typeerror_default_is_not_float(simple_box: SecretBox) -> None:
+    # Type guarding the default value to ensure .get() always returns a float
+    with pytest.raises(TypeError):
+        simple_box.get_float("answer", "42")  # type: ignore
+
+
+def test_get_float_raises_valueerror_on_convert_error(simple_box: SecretBox) -> None:
+    # If the value cannot be converted to an float, raise ValueError
+    with pytest.raises(ValueError):
+        simple_box.get_float("foo")
+
+
+def test_get_float_fails_when_value_is_ing(simple_box: SecretBox) -> None:
+    # We do not want type coercion to happen
+    with pytest.raises(ValueError):
+        simple_box.get_float("answer")


### PR DESCRIPTION
This method will attempt to return the requested value as a float. For the case of "42", Python will coerce the type to a float. This, however, changes the defined value of 42 to 42.0. In this case the method will raise a ValueError.